### PR TITLE
added initial appveyor CI config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,67 @@
+version: 1.0.1.5.{build}
+image: Visual Studio 2017
+
+
+environment:
+  matrix:
+    - PlatformToolset: v141_xp
+
+platform:
+    - x64
+    - x86
+
+configuration:
+    - Release
+    - Debug
+
+install:
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="x64" set platform_input=x64
+    - if "%platform%"=="x86" set archi=x86
+    - if "%platform%"=="x86" set platform_input=Win32
+    - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+
+build:
+    parallel: true                  # enable MSBuild parallel builds
+    verbosity: minimal
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"\projects\msvc2017
+    # don't build cmdline_linux on windows
+    - msbuild nppcrypt.sln /m /t:cmdline;cryptlib;nppcrypt /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - ps: >-
+
+        if ($env:CONFIGURATION -eq "Release") {
+            Push-AppveyorArtifact "bin\nppcrypt\$env:PLATFORM\$env:CONFIGURATION\nppcrypt.dll" -FileName nppcrypt.dll
+        }
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v141_xp") {
+            if($env:PLATFORM -eq "x64"){
+            $ZipFileName = "nppcrypt_$($env:APPVEYOR_REPO_TAG_NAME)_x64.zip"
+            7z a $ZipFileName bin\nppcrypt\$env:PLATFORM\$env:CONFIGURATION\nppcrypt.dll
+            }
+            if($env:PLATFORM -eq "x86"){
+            $ZipFileName = "nppcrypt_$($env:APPVEYOR_REPO_TAG_NAME)_x86.zip"
+            7z a $ZipFileName bin\nppcrypt\$env:PLATFORM\$env:CONFIGURATION\nppcrypt.dll
+            }
+        }
+ 
+artifacts:
+  - path: nppcrypt_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        PlatformToolset: v141_xp
+        configuration: Release


### PR DESCRIPTION
, see https://ci.appveyor.com/project/chcg/nppcrypt/build/1.0.1.5.8

Prepared to be extended to automatically create release at github on tagging, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
Needs a github token, encrypted by appveyor under  secure: ...