### PR TITLE
Fix building issues on Linux

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,6 +9,7 @@ CFLAGS :=
 CRYPTOPP := src/cryptopp/libcryptopp.a
 LDFLAGS := -lstdc++ -Lsrc/cryptopp -lcryptopp
 PREFIX := /usr/local
+unexport LDFLAGS
 
 DEP_SRC := $(shell find $(SRCDIR)/bcrypt -type f -name *.cpp)
 DEP_SRC += $(shell find $(SRCDIR)/scrypt -type f -name *.c)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,7 +31,11 @@ DEP_OBJ := $(patsubst $(SRCDIR)/%,$(OBJDIR)/$(SUBDIR)/%,$(patsubst %.cpp,%.o,$(p
 MAIN_OBJ := $(patsubst $(SRCDIR)/%,$(OBJDIR)/$(SUBDIR)/%,$(MAIN_SRC:.cpp=.o))
 
 .PHONY: all
-all: info directories $(CRYPTOPP) bin/$(SUBDIR)/$(TARGET)
+all:
+	$(MAKE) info
+	$(MAKE) directories
+	$(MAKE) $(CRYPTOPP)
+	$(MAKE) bin/$(SUBDIR)/$(TARGET)
 
 .PHONY: info
 info:
@@ -73,7 +77,7 @@ else
 endif
 
 $(CRYPTOPP):
-	@make -C src/cryptopp
+	$(MAKE) -C src/cryptopp
 
 bin/$(SUBDIR)/$(TARGET): $(MAIN_OBJ) $(DEP_OBJ)
 	$(CXX) $(CXXFLAGS) -o bin/$(SUBDIR)/$(TARGET) $^ $(LDFLAGS)

--- a/src/clihelp.cpp
+++ b/src/clihelp.cpp
@@ -85,7 +85,7 @@ bool setLocale()
     return ret;
 }
 
-void readLine(crypt::secure_string& out)
+void readLine(nppcrypt::secure_string& out)
 {
 #ifdef WIN32
     HANDLE hConsole = GetStdHandle(STD_INPUT_HANDLE);

--- a/src/clihelp.h
+++ b/src/clihelp.h
@@ -21,6 +21,6 @@ GNU General Public License for more details.
 /* Set console echo (in own file because unistd.h pollutes the global namespace...) */
 void setEcho(bool enable = true);
 bool setLocale();
-void readLine(crypt::secure_string& out);
+void readLine(nppcrypt::secure_string& out);
 
 #endif

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -275,25 +275,25 @@ namespace help
         }
     }
 
-    bool setUserData(const char* s, size_t len, crypt::UserData& d, crypt::Encoding default_enc)
+    bool setUserData(const char* s, size_t len, nppcrypt::UserData& d, nppcrypt::Encoding default_enc)
     {
         if (cmpchars(s, len, "hex:", 4)) {
-            d.set(s + 4, len - 4, crypt::Encoding::base16);
+            d.set(s + 4, len - 4, nppcrypt::Encoding::base16);
         } else if (cmpchars(s, len, "base32:", 7)) {
-            d.set(s + 7, len - 7, crypt::Encoding::base32);
+            d.set(s + 7, len - 7, nppcrypt::Encoding::base32);
         } else if (cmpchars(s, len, "base64:", 7)) {
-            d.set(s + 7, len - 7, crypt::Encoding::base64);
+            d.set(s + 7, len - 7, nppcrypt::Encoding::base64);
         } else if (cmpchars(s, len, "utf8:", 5)) {
-            d.set(s, len, crypt::Encoding::ascii);
+            d.set(s, len, nppcrypt::Encoding::ascii);
         } else {
             d.set(s, len, default_enc);
         }
         return (d.size() > 0);
     }
 
-    bool getUserInput(const char* msg, crypt::UserData& data, crypt::Encoding default_enc, size_t trys, bool repeat, bool echo)
+    bool getUserInput(const char* msg, nppcrypt::UserData& data, nppcrypt::Encoding default_enc, size_t trys, bool repeat, bool echo)
     {
-        crypt::secure_string input1, input2;
+        nppcrypt::secure_string input1, input2;
         size_t counter = 0;
         setEcho(echo);
         while (true) {
@@ -329,10 +329,10 @@ namespace help
 namespace check
 {
     /* -p --password , default encoding: utf8 */
-    void password(crypt::UserData& password)
+    void password(nppcrypt::UserData& password)
     {
         if (opt.password->count()) {
-            help::setUserData(args.password.c_str(), args.password.size(), password, crypt::Encoding::ascii);
+            help::setUserData(args.password.c_str(), args.password.size(), password, nppcrypt::Encoding::ascii);
             for (size_t i = 0; i < args.password.size(); i++) {
                 args.password[i] = 0;
             }
@@ -341,34 +341,34 @@ namespace check
             if (*opt.nointeraction) {
                 throwInvalid(missing_password);
             }
-            if (!help::getUserInput("enter password", password, crypt::Encoding::ascii, 3, true, false)) {
+            if (!help::getUserInput("enter password", password, nppcrypt::Encoding::ascii, 3, true, false)) {
                 throwInvalid(missing_password);
             }
         }
     }
 
     /* -c --cipher , i.e.: -c aria:32:gcm */
-    void cipher(crypt::Options::Crypt& options)
+    void cipher(nppcrypt::Options::Crypt& options)
     {
         if (opt.cipher->count()) {
             std::vector<size_t> pos;
             help::splitArgument(args.cipher, pos, ':');
 
-            if (!crypt::help::getCipher(args.cipher.c_str(), options.cipher)) {
+            if (!nppcrypt::help::getCipher(args.cipher.c_str(), options.cipher)) {
                 throwInvalid(invalid_cipher);
             }
             if (pos.size() > 1) {
                 options.key.length = std::atoi(&args.cipher[pos[1]]) / 8;
                 if (pos.size() > 2) {
-                    if (!crypt::help::getCipherMode(&args.cipher[pos[2]], options.mode)) {
+                    if (!nppcrypt::help::getCipherMode(&args.cipher[pos[2]], options.mode)) {
                         throwInvalid(invalid_mode);
                     }
                 } else {
-                    if (!crypt::help::checkProperty(options.cipher, crypt::STREAM)) {
-                        if (crypt::help::checkCipherMode(options.cipher, crypt::Mode::gcm)) {
-                            options.mode = crypt::Mode::gcm;
+                    if (!nppcrypt::help::checkProperty(options.cipher, nppcrypt::STREAM)) {
+                        if (nppcrypt::help::checkCipherMode(options.cipher, nppcrypt::Mode::gcm)) {
+                            options.mode = nppcrypt::Mode::gcm;
                         } else {
-                            options.mode = crypt::Mode::cbc;
+                            options.mode = nppcrypt::Mode::cbc;
                         }
                     }
                 }
@@ -377,16 +377,16 @@ namespace check
     }
 
     /* -e --encoding, i.e. -e base16:unix:96:true [encoding:eol:linelength:uppercase] */
-    void encoding(crypt::Options::Crypt& options)
+    void encoding(nppcrypt::Options::Crypt& options)
     {
         if (opt.encoding->count()) {
             std::vector<size_t> pos;
             help::splitArgument(args.encoding, pos, ':');
-            if (!crypt::help::getEncoding(args.encoding.c_str(), options.encoding.enc)) {
+            if (!nppcrypt::help::getEncoding(args.encoding.c_str(), options.encoding.enc)) {
                 throwInvalid(invalid_encoding);
             }
             if (pos.size() > 1) {
-                if (!crypt::help::getEOL(&args.encoding[pos[1]], options.encoding.eol)) {
+                if (!nppcrypt::help::getEOL(&args.encoding[pos[1]], options.encoding.eol)) {
                     throwInvalid(invalid_eol);
                 }
                 if (pos.size() > 2) {
@@ -411,20 +411,20 @@ namespace check
             -k pbkdf2:sha3:256:1000 [pbkdf2 with sha3-256 and 1000 iterations]
             -k bcrypt:7 [bcrypt with 2^7 iterations]
     */
-    void keyderivation(crypt::Options::Crypt& options)
+    void keyderivation(nppcrypt::Options::Crypt& options)
     {
         if (opt.keyderivation->count()) {
             std::vector<size_t> pos;
             help::splitArgument(args.keyderivation, pos, ':');
-            if (!crypt::help::getKeyDerivation(args.keyderivation.c_str(), options.key.algorithm)) {
+            if (!nppcrypt::help::getKeyDerivation(args.keyderivation.c_str(), options.key.algorithm)) {
                 throwInvalid(invalid_keyderivation);
             }
             switch (options.key.algorithm) {
-            case crypt::KeyDerivation::pbkdf2:
+            case nppcrypt::KeyDerivation::pbkdf2:
             {
                 if (pos.size() > 1) {
-                    crypt::Hash thash;
-                    if (!crypt::help::getHash(&args.keyderivation[pos[1]], thash)) {
+                    nppcrypt::Hash thash;
+                    if (!nppcrypt::help::getHash(&args.keyderivation[pos[1]], thash)) {
                         throwInvalid(invalid_pbkdf2);
                     }
                     options.key.options[0] = static_cast<int>(thash);
@@ -433,30 +433,30 @@ namespace check
                         if (pos.size() > 3) {
                             options.key.options[2] = std::atoi(&args.keyderivation[pos[3]]);
                         } else {
-                            options.key.options[2] = crypt::Constants::pbkdf2_iter_default;
+                            options.key.options[2] = nppcrypt::Constants::pbkdf2_iter_default;
                         }
                     } else {
                         options.key.options[1] = 0;
-                        options.key.options[2] = crypt::Constants::pbkdf2_iter_default;
+                        options.key.options[2] = nppcrypt::Constants::pbkdf2_iter_default;
                     }
                 } else {
-                    options.key.options[0] = static_cast<int>(crypt::Constants::pbkdf2_default_hash);
-                    options.key.options[1] = static_cast<int>(crypt::Constants::pbkdf2_default_hash_digest);
-                    options.key.options[2] = crypt::Constants::pbkdf2_iter_default;
+                    options.key.options[0] = static_cast<int>(nppcrypt::Constants::pbkdf2_default_hash);
+                    options.key.options[1] = static_cast<int>(nppcrypt::Constants::pbkdf2_default_hash_digest);
+                    options.key.options[2] = nppcrypt::Constants::pbkdf2_iter_default;
                 }
 
                 break;
             }
-            case crypt::KeyDerivation::bcrypt:
+            case nppcrypt::KeyDerivation::bcrypt:
             {
                 if (pos.size() > 1) {
                     options.key.options[0] = std::atoi(&args.keyderivation[pos[1]]);
                 } else {
-                    options.key.options[0] = crypt::Constants::bcrypt_iter_default;
+                    options.key.options[0] = nppcrypt::Constants::bcrypt_iter_default;
                 }
                 break;
             }
-            case crypt::KeyDerivation::scrypt:
+            case nppcrypt::KeyDerivation::scrypt:
             {
                 if (pos.size() > 1) {
                     options.key.options[0] = std::atoi(&args.keyderivation[pos[1]]);
@@ -465,13 +465,13 @@ namespace check
                         if (pos.size() > 3) {
                             options.key.options[2] = std::atoi(&args.keyderivation[pos[3]]);
                         } else {
-                            options.key.options[2] = crypt::Constants::scrypt_p_default;
+                            options.key.options[2] = nppcrypt::Constants::scrypt_p_default;
                         }
                     } else {
-                        options.key.options[1] = crypt::Constants::scrypt_r_default;
+                        options.key.options[1] = nppcrypt::Constants::scrypt_r_default;
                     }
                 } else {
-                    options.key.options[0] = crypt::Constants::scrypt_N_default;
+                    options.key.options[0] = nppcrypt::Constants::scrypt_N_default;
                 }
                 break;
             }
@@ -486,12 +486,12 @@ namespace check
             std::vector<size_t> pos;
             help::splitArgument(args.hmac, pos, ':');
 
-            if (!crypt::help::getHash(args.hmac.c_str(), hmac.hash.algorithm) || !crypt::help::checkProperty(hmac.hash.algorithm, crypt::HMAC_SUPPORT)) {
+            if (!nppcrypt::help::getHash(args.hmac.c_str(), hmac.hash.algorithm) || !nppcrypt::help::checkProperty(hmac.hash.algorithm, nppcrypt::HMAC_SUPPORT)) {
                 throwInvalid(invalid_hmac_hash);
             }
             if (pos.size() > 1) {
                 hmac.hash.digest_length = (size_t)std::atoi(&args.hmac[pos[1]]) / 8;
-                if (!crypt::help::checkHashDigest(hmac.hash.algorithm, hmac.hash.digest_length)) {
+                if (!nppcrypt::help::checkHashDigest(hmac.hash.algorithm, hmac.hash.digest_length)) {
                     throwInvalid(invalid_hmac_hash);
                 }
             }
@@ -500,13 +500,13 @@ namespace check
         }
         if (hmac.enable) {
             if (opt.hash_key->count()) {
-                help::setUserData(args.hash_key.c_str(), args.hash_key.size(), hmac.hash.key, crypt::Encoding::ascii);
+                help::setUserData(args.hash_key.c_str(), args.hash_key.size(), hmac.hash.key, nppcrypt::Encoding::ascii);
             }
             if (!hmac.hash.key.size()) {
                 if (*opt.nointeraction) {
                     throwInvalid(missing_hmac_key);
                 }
-                if (!help::getUserInput("enter HMAC key", hmac.hash.key, crypt::Encoding::ascii, 2, true, false)) {
+                if (!help::getUserInput("enter HMAC key", hmac.hash.key, nppcrypt::Encoding::ascii, 2, true, false)) {
                     throwInvalid(missing_hmac_key);
                 }
             }
@@ -514,16 +514,16 @@ namespace check
     }
 
     /* -t --tag , default-encoding: base64 [decryption] */
-    void tag(const crypt::Options::Crypt& options, crypt::UserData& tag)
+    void tag(const nppcrypt::Options::Crypt& options, nppcrypt::UserData& tag)
     {
         if (opt.tag->count()) {
-            help::setUserData(args.tag.c_str(), args.tag.size(), tag, crypt::Encoding::base64);
+            help::setUserData(args.tag.c_str(), args.tag.size(), tag, nppcrypt::Encoding::base64);
         }
-        if (!crypt::help::checkProperty(options.cipher, crypt::STREAM) && (options.mode == crypt::Mode::ccm || options.mode == crypt::Mode::gcm || options.mode == crypt::Mode::eax) && !tag.size()) {
+        if (!nppcrypt::help::checkProperty(options.cipher, nppcrypt::STREAM) && (options.mode == nppcrypt::Mode::ccm || options.mode == nppcrypt::Mode::gcm || options.mode == nppcrypt::Mode::eax) && !tag.size()) {
             if (*opt.nointeraction) {
                 throwInvalid(invalid_tag);
             }
-            if (!help::getUserInput("please specify tag", tag, crypt::Encoding::base64, 2, false, true)) {
+            if (!help::getUserInput("please specify tag", tag, nppcrypt::Encoding::base64, 2, false, true)) {
                 throwInvalid(invalid_tag);
             }
         }
@@ -533,51 +533,51 @@ namespace check
             -v random [default]
             -v YXNkZmFzZGZhc2RmYXNkZg== [custom iv, default-encoding: base64]
             -v base16:01A2C1... */
-    void iv(crypt::Options::Crypt& options, crypt::UserData& iv, bool decryption)
+    void iv(nppcrypt::Options::Crypt& options, nppcrypt::UserData& iv, bool decryption)
     {
         if (opt.iv->count()) {
             if (args.iv.size() == 6 && args.iv.compare("random") == 0) {
-                options.iv = crypt::IV::random;
+                options.iv = nppcrypt::IV::random;
             } else if (args.iv.size() == 4 && args.iv.compare("zero") == 0) {
-                options.iv = crypt::IV::zero;
+                options.iv = nppcrypt::IV::zero;
             } else if (args.iv.size() == 13 && args.iv.compare("keyderivation") == 0) {
-                options.iv = crypt::IV::keyderivation;
+                options.iv = nppcrypt::IV::keyderivation;
             } else {
-                options.iv = crypt::IV::custom;
-                if (!help::setUserData(args.iv.c_str(), args.iv.size(), iv, crypt::Encoding::base64)) {
+                options.iv = nppcrypt::IV::custom;
+                if (!help::setUserData(args.iv.c_str(), args.iv.size(), iv, nppcrypt::Encoding::base64)) {
                     throwInvalid(missing_iv);
                 }
             }
         }
-        if (decryption && (options.iv != crypt::IV::zero && options.iv != crypt::IV::keyderivation) && !iv.size()) {
+        if (decryption && (options.iv != nppcrypt::IV::zero && options.iv != nppcrypt::IV::keyderivation) && !iv.size()) {
             if (*opt.nointeraction) {
                 throwInvalid(missing_iv);
             }
-            if (!help::getUserInput("IV data missing. please specify", iv, crypt::Encoding::base64, 2, false, true)) {
+            if (!help::getUserInput("IV data missing. please specify", iv, nppcrypt::Encoding::base64, 2, false, true)) {
                 throwInvalid(missing_iv);
             }
         }
     }
 
     /* -s --salt [decryption] */
-    void salt(crypt::Options::Crypt& options, crypt::UserData& salt)
+    void salt(nppcrypt::Options::Crypt& options, nppcrypt::UserData& salt)
     {
         if (opt.salt->count()) {
-            help::setUserData(args.salt.c_str(), args.salt.size(), salt, crypt::Encoding::base64);
+            help::setUserData(args.salt.c_str(), args.salt.size(), salt, nppcrypt::Encoding::base64);
             options.key.salt_bytes = salt.size();
         }
         if (options.key.salt_bytes > 0 && !salt.size()) {
             if (*opt.nointeraction) {
                 throwInvalid(missing_salt);
             }
-            if (!help::getUserInput("salt data missing. please specify", salt, crypt::Encoding::base64, 2, false, true)) {
+            if (!help::getUserInput("salt data missing. please specify", salt, nppcrypt::Encoding::base64, 2, false, true)) {
                 throwInvalid(missing_salt);
             }
         }
     }
 
     /* -s --salt [encryption] */
-    void salt(crypt::Options::Crypt& options)
+    void salt(nppcrypt::Options::Crypt& options)
     {
         if (opt.salt->count()) {
             options.key.salt_bytes = std::atoi(args.salt.c_str());
@@ -597,17 +597,17 @@ namespace check
     }
 
     /* -h --hash */
-    void hash(crypt::Options::Hash& options)
+    void hash(nppcrypt::Options::Hash& options)
     {
         std::vector<size_t> pos;
         help::splitArgument(args.hash, pos, ':');
 
-        if (!crypt::help::getHash(args.hash.c_str(), options.algorithm)) {
+        if (!nppcrypt::help::getHash(args.hash.c_str(), options.algorithm)) {
             throwInvalid(invalid_hash);
         }
         if (pos.size() > 1) {
             options.digest_length = std::atoi(&args.hash[pos[1]]) / 8;
-            if (!crypt::help::checkHashDigest(options.algorithm, options.digest_length)) {
+            if (!nppcrypt::help::checkHashDigest(options.algorithm, options.digest_length)) {
                 throwInvalid(invalid_hash);
             }
         } else {
@@ -615,32 +615,32 @@ namespace check
         }
 
         if (opt.hash_key->count()) {
-            if (!help::setUserData(args.hash_key.c_str(), args.hash_key.size(), options.key, crypt::Encoding::ascii)) {
+            if (!help::setUserData(args.hash_key.c_str(), args.hash_key.size(), options.key, nppcrypt::Encoding::ascii)) {
                 if (*opt.nointeraction) {
                     throwInvalid(invalid_hash_key);
                 }
-                if (!help::getUserInput("enter key", options.key, crypt::Encoding::ascii, 2, true, false)) {
+                if (!help::getUserInput("enter key", options.key, nppcrypt::Encoding::ascii, 2, true, false)) {
                     throwInvalid(invalid_hash_key);
                 }
             }
             options.use_key = true;
         }
         if (options.use_key) {
-            if (!crypt::help::checkProperty(options.algorithm, crypt::KEY_SUPPORT)) {
-                if (crypt::help::checkProperty(options.algorithm, crypt::HMAC_SUPPORT)) {
+            if (!nppcrypt::help::checkProperty(options.algorithm, nppcrypt::KEY_SUPPORT)) {
+                if (nppcrypt::help::checkProperty(options.algorithm, nppcrypt::HMAC_SUPPORT)) {
                     if (!*opt.silent) {
-                        std::cout << crypt::help::getString(options.algorithm) << " does not support key input. using HMAC ..." << std::endl;
+                        std::cout << nppcrypt::help::getString(options.algorithm) << " does not support key input. using HMAC ..." << std::endl;
                     }
                 } else {
                     if (!*opt.silent) {
-                        std::cout << crypt::help::getString(options.algorithm) << " does not support key input. ignoring --hash-key ..." << std::endl;
+                        std::cout << nppcrypt::help::getString(options.algorithm) << " does not support key input. ignoring --hash-key ..." << std::endl;
                     }
                     options.use_key = false;
                 }
             }
         }
 
-        if (crypt::help::checkProperty(options.algorithm, crypt::KEY_REQUIRED) && !options.use_key) {
+        if (nppcrypt::help::checkProperty(options.algorithm, nppcrypt::KEY_REQUIRED) && !options.use_key) {
             throwInvalid(hash_requires_key);
         }
     }
@@ -648,51 +648,51 @@ namespace check
 
 namespace print
 {
-    void options(const crypt::Options::Crypt& options)
+    void options(const nppcrypt::Options::Crypt& options)
     {
         size_t c_keylen = options.key.length;
         size_t c_ivlen, c_blocksize;
         getCipherInfo(options.cipher, options.mode, c_keylen, c_ivlen, c_blocksize);
 
-        std::cout << "options: " << crypt::help::getString(options.cipher) << "-" << c_keylen * 8;
-        if (!crypt::help::checkProperty(options.cipher, crypt::STREAM)) {
-            std::cout << "-" << crypt::help::getString(options.mode);
+        std::cout << "options: " << nppcrypt::help::getString(options.cipher) << "-" << c_keylen * 8;
+        if (!nppcrypt::help::checkProperty(options.cipher, nppcrypt::STREAM)) {
+            std::cout << "-" << nppcrypt::help::getString(options.mode);
         }
-        std::cout << ", iv: " << c_ivlen << " bytes (" << crypt::help::getString(options.iv) << "), " << crypt::help::getString(options.key.algorithm);;
+        std::cout << ", iv: " << c_ivlen << " bytes (" << nppcrypt::help::getString(options.iv) << "), " << nppcrypt::help::getString(options.key.algorithm);;
 
         switch (options.key.algorithm) {
-        case crypt::KeyDerivation::pbkdf2:
+        case nppcrypt::KeyDerivation::pbkdf2:
         {
-            std::cout << " (" << crypt::help::getString(crypt::Hash(options.key.options[0])) << "-" << options.key.options[1] * 8 << ", " << options.key.options[2] << " iterations)";
+            std::cout << " (" << nppcrypt::help::getString(nppcrypt::Hash(options.key.options[0])) << "-" << options.key.options[1] * 8 << ", " << options.key.options[2] << " iterations)";
             break;
         }
-        case crypt::KeyDerivation::bcrypt:
+        case nppcrypt::KeyDerivation::bcrypt:
         {
             std::cout << " (2^" << options.key.options[0] << " iterations)";
             break;
         }
-        case crypt::KeyDerivation::scrypt:
+        case nppcrypt::KeyDerivation::scrypt:
         {
             std::cout << " (N:2^" << options.key.options[0] << ", r:" << options.key.options[1] << ", p:" << options.key.options[2] << ")";
         }
         }
-        std::cout << ", encoding: " << crypt::help::getString(options.encoding.enc) << std::endl;
+        std::cout << ", encoding: " << nppcrypt::help::getString(options.encoding.enc) << std::endl;
     }
 
-    void initdata(const crypt::Options::Crypt& options, const crypt::InitData& initdata)
+    void initdata(const nppcrypt::Options::Crypt& options, const nppcrypt::InitData& initdata)
     {
-        using namespace crypt;
+        using namespace nppcrypt;
         secure_string tstr;
         if (options.key.salt_bytes && initdata.salt.size()) {
-            initdata.salt.get(tstr, crypt::Encoding::base64);
+            initdata.salt.get(tstr, nppcrypt::Encoding::base64);
             std::cout << "Salt: " << tstr << std::endl;;
         }
         if ((options.mode == Mode::gcm || options.mode == Mode::ccm || options.mode == Mode::eax) && initdata.tag.size()) {
-            initdata.tag.get(tstr, crypt::Encoding::base64);
+            initdata.tag.get(tstr, nppcrypt::Encoding::base64);
             std::cout << "Tag: " << tstr << std::endl;
         }
         if (options.iv == IV::random && initdata.iv.size()) {
-            initdata.iv.get(tstr, crypt::Encoding::base64);
+            initdata.iv.get(tstr, nppcrypt::Encoding::base64);
             std::cout << "IV: " << tstr << std::endl;
         }
     }
@@ -707,36 +707,36 @@ namespace print
 
 void hash(const std::string& filename)
 {
-    std::basic_string<crypt::byte>    buffer;
+    std::basic_string<nppcrypt::byte>    buffer;
     std::vector<std::string>          digests;
-    crypt::Options::Hash              options;
+    nppcrypt::Options::Hash              options;
     std::ostringstream                out;
     /* default algorithms */
-    static const crypt::Hash    thashes[5] = { crypt::Hash::crc32, crypt::Hash::md5, crypt::Hash::sha1, crypt::Hash::sha2, crypt::Hash::sha3 };
+    static const nppcrypt::Hash    thashes[5] = { nppcrypt::Hash::crc32, nppcrypt::Hash::md5, nppcrypt::Hash::sha1, nppcrypt::Hash::sha2, nppcrypt::Hash::sha3 };
     static const size_t         thashes_digests[5] = { 4, 16, 20, 32, 32 };
 
-    if (opt.encoding->count() && !crypt::help::getEncoding(args.encoding.c_str(), options.encoding)) {
+    if (opt.encoding->count() && !nppcrypt::help::getEncoding(args.encoding.c_str(), options.encoding)) {
         throwInvalid(invalid_encoding);
     }
 
     if (opt.hash->count()) {
         check::hash(options);
-        crypt::hash(options, buffer, filename);
+        nppcrypt::hash(options, buffer, filename);
         digests.push_back(std::string(buffer.begin(), buffer.end()));
-        out << crypt::help::getString(options.algorithm) << "-" << options.digest_length * 8 << ": " << (const char*)buffer.c_str() << std::endl;
+        out << nppcrypt::help::getString(options.algorithm) << "-" << options.digest_length * 8 << ": " << (const char*)buffer.c_str() << std::endl;
     } else {
         for (size_t i = 0; i < 5; i++) {
             options.algorithm = thashes[i];
             options.digest_length = thashes_digests[i];
-            crypt::hash(options, buffer, filename);
-            out << crypt::help::getString(options.algorithm) << ": " << (const char*)buffer.c_str() << std::endl;
+            nppcrypt::hash(options, buffer, filename);
+            out << nppcrypt::help::getString(options.algorithm) << ": " << (const char*)buffer.c_str() << std::endl;
         }
     }
 
     if (opt.output->count()) {
         std::string temp = out.str();
         FileWriter fout(args.output);
-        if (!fout.write((const crypt::byte*)temp.c_str(), temp.size())) {
+        if (!fout.write((const nppcrypt::byte*)temp.c_str(), temp.size())) {
             throwError(failed_to_write_file);
         }
     } else {
@@ -757,9 +757,9 @@ void hash(const std::string& filename)
                     std::cout << "no match." << std::endl;
                 } else {
                     if (opt.hash->count()) {
-                        std::cout << crypt::help::getString(options.algorithm) << " matches." << std::endl;
+                        std::cout << nppcrypt::help::getString(options.algorithm) << " matches." << std::endl;
                     } else {
-                        std::cout << crypt::help::getString(thashes[i]) << " matches." << std::endl;
+                        std::cout << nppcrypt::help::getString(thashes[i]) << " matches." << std::endl;
                     }
                 }
             }
@@ -767,29 +767,29 @@ void hash(const std::string& filename)
     }
 }
 
-void hash(const crypt::byte* input, size_t input_length)
+void hash(const nppcrypt::byte* input, size_t input_length)
 {
-    std::basic_string<crypt::byte>  buffer;
-    crypt::Options::Hash            options;
+    std::basic_string<nppcrypt::byte>  buffer;
+    nppcrypt::Options::Hash            options;
     std::ostringstream              out;
 
-    if (opt.encoding->count() && !crypt::help::getEncoding(args.encoding.c_str(), options.encoding)) {
+    if (opt.encoding->count() && !nppcrypt::help::getEncoding(args.encoding.c_str(), options.encoding)) {
         throwInvalid(invalid_encoding);
     }
 
     if (opt.hash->count()) {
         check::hash(options);
     } else {
-        options.algorithm = crypt::Hash::md5;
+        options.algorithm = nppcrypt::Hash::md5;
         options.digest_length = 16;
     }
-    crypt::hash(options, buffer, { { input, input_length } });
-    out << crypt::help::getString(options.algorithm) << "-" << options.digest_length * 8 << ": " << (const char*)buffer.c_str() << std::endl;
+    nppcrypt::hash(options, buffer, { { input, input_length } });
+    out << nppcrypt::help::getString(options.algorithm) << "-" << options.digest_length * 8 << ": " << (const char*)buffer.c_str() << std::endl;
     
     if (opt.output->count()) {
         std::string temp = out.str();
         FileWriter fout(args.output);
-        if (!fout.write((const crypt::byte*)temp.c_str(), temp.size())) {
+        if (!fout.write((const nppcrypt::byte*)temp.c_str(), temp.size())) {
             throwError(failed_to_write_file);
         }
     } else {
@@ -797,14 +797,14 @@ void hash(const crypt::byte* input, size_t input_length)
     }
 }
 
-void decrypt(const crypt::byte* input, size_t input_length, File::BOM bom)
+void decrypt(const nppcrypt::byte* input, size_t input_length, File::BOM bom)
 {
-    std::basic_string<crypt::byte>  outputData;
-    crypt::Options::Crypt           options;
-    crypt::UserData                 password;
+    std::basic_string<nppcrypt::byte>  outputData;
+    nppcrypt::Options::Crypt           options;
+    nppcrypt::UserData                 password;
     CryptHeader::HMAC               hmac;
     CryptHeaderReader               header(hmac);
-    crypt::InitData                   init;
+    nppcrypt::InitData                   init;
 
     if (bom != File::BOM::utf8 && bom != File::BOM::none) {
         throwInvalid(cmdline_only_utf8);
@@ -824,7 +824,7 @@ void decrypt(const crypt::byte* input, size_t input_length, File::BOM bom)
     check::outputfile();
     check::hmac(hmac);
 
-    crypt::help::validate(options);
+    nppcrypt::help::validate(options);
 
     if (verbose) {
         print::outputfile();
@@ -840,9 +840,9 @@ void decrypt(const crypt::byte* input, size_t input_length, File::BOM bom)
                 throwInfo(hmac_auth_failed);
             }
         }
-        crypt::decrypt(header.getEncrypted(), header.getEncryptedLength(), outputData, options, password, init);
+        nppcrypt::decrypt(header.getEncrypted(), header.getEncryptedLength(), outputData, options, password, init);
     } else {
-        crypt::decrypt(input, input_length, outputData, options, password, init);
+        nppcrypt::decrypt(input, input_length, outputData, options, password, init);
     }
     if (opt.output->count()) {
         FileWriter fout(args.output, bom);
@@ -854,14 +854,14 @@ void decrypt(const crypt::byte* input, size_t input_length, File::BOM bom)
     }
 }
 
-void encrypt(const crypt::byte* input, size_t input_length)
+void encrypt(const nppcrypt::byte* input, size_t input_length)
 {
-    std::basic_string<crypt::byte>  outputData;
-    crypt::Options::Crypt           options;
-    crypt::UserData                 password;
+    std::basic_string<nppcrypt::byte>  outputData;
+    nppcrypt::Options::Crypt           options;
+    nppcrypt::UserData                 password;
     CryptHeader::HMAC               hmac;
     CryptHeaderWriter               header(hmac);
-    crypt::InitData                 init;
+    nppcrypt::InitData                 init;
 
     bool verbose = !*opt.silent;
     bool create_header = !*opt.noheader;
@@ -876,14 +876,14 @@ void encrypt(const crypt::byte* input, size_t input_length)
     check::hmac(hmac);
     check::outputfile();
 
-    crypt::help::validate(options);
+    nppcrypt::help::validate(options);
 
     if (verbose) {
         print::outputfile();
         print::options(options);
     }
     
-    crypt::encrypt(input, input_length, outputData, options, password, init);
+    nppcrypt::encrypt(input, input_length, outputData, options, password, init);
 
     if (create_header) {
         header.create(options, init, outputData.c_str(), outputData.size());
@@ -952,7 +952,7 @@ int main(int argc, char** argv)
             }
         }
         
-        std::basic_string<crypt::byte> inputData;
+        std::basic_string<nppcrypt::byte> inputData;
         File::BOM bom = File::BOM::none;
 
         if (File::exists(args.input)) {

--- a/src/crypt.cpp
+++ b/src/crypt.cpp
@@ -87,7 +87,7 @@ extern "C" {
 #include "cryptopp/crc.h"
 #include "cryptopp/siphash.h"
 
-using namespace crypt;
+using namespace nppcrypt;
 
 template<typename T>
 T ipow(T base, T exp)
@@ -108,16 +108,16 @@ namespace Strings
     static const std::string eol[3] = { "\r\n", "\n", "\r" };
 };
 
-crypt::ExceptionError::ExceptionError(const std::string &m, const char* func, int ln) noexcept : line(ln)
+nppcrypt::ExceptionError::ExceptionError(const std::string &m, const char* func, int ln) noexcept : line(ln)
 {
     std::ostringstream o;
     o << "[" << func << ":" << line << "] " << m;
     msg.assign(o.str());
 }
 
-#define throwInfo(arg) throw crypt::ExceptionInfo(arg);
-#define throwInvalid(arg) throw crypt::ExceptionArguments(arg);
-#define throwError(arg) throw crypt::ExceptionError(arg, __func__, __LINE__);
+#define throwInfo(arg) throw nppcrypt::ExceptionInfo(arg);
+#define throwInvalid(arg) throw nppcrypt::ExceptionArguments(arg);
+#define throwError(arg) throw nppcrypt::ExceptionError(arg, __func__, __LINE__);
 
 // ===========================================================================================================================================================================================
 // TODO: maybe the factory should be used ... ( cryptopp/factory.h )
@@ -797,7 +797,7 @@ namespace intern
         return NULL;
     }
 
-    CryptoPP::HashTransformation* getHashTransformation(crypt::Options::Hash options)
+    CryptoPP::HashTransformation* getHashTransformation(nppcrypt::Options::Hash options)
     {
         using namespace CryptoPP;
 
@@ -1079,7 +1079,7 @@ namespace intern
         return NULL;
     }
 
-    void calcKey(CryptoPP::SecByteBlock& key, const UserData& password, const UserData& salt, const crypt::Options::Crypt::Key& opt)
+    void calcKey(CryptoPP::SecByteBlock& key, const UserData& password, const UserData& salt, const nppcrypt::Options::Crypt::Key& opt)
     {
         using namespace CryptoPP;
         switch (opt.algorithm)
@@ -1133,7 +1133,7 @@ namespace intern
 
 // ===========================================================================================================================================================================================
 
-bool crypt::EncodingAlphabet::setup(const char* alphabet, byte padding)
+bool nppcrypt::EncodingAlphabet::setup(const char* alphabet, byte padding)
 {
     size_t length = strlen(alphabet);
     if (length == 32) {
@@ -1157,15 +1157,15 @@ bool crypt::EncodingAlphabet::setup(const char* alphabet, byte padding)
 
 // ===========================================================================================================================================================================================
 
-crypt::UserData::UserData()
+nppcrypt::UserData::UserData()
 {
 }
 
-crypt::UserData::UserData(const char* s, Encoding enc)
+nppcrypt::UserData::UserData(const char* s, Encoding enc)
 {
     set(s, strlen(s), enc);
 }
-const byte* crypt::UserData::BytePtr() const
+const byte* nppcrypt::UserData::BytePtr() const
 {
     if (data.size()) {
         return data.BytePtr();
@@ -1174,18 +1174,18 @@ const byte* crypt::UserData::BytePtr() const
     }
 }
 
-size_t crypt::UserData::size() const
+size_t nppcrypt::UserData::size() const
 {
     return data.size();
 }
 
-size_t crypt::UserData::set(const UserData& s)
+size_t nppcrypt::UserData::set(const UserData& s)
 {
     data.Assign(s.BytePtr(), s.size());
     return data.size();
 }
 
-size_t crypt::UserData::set(std::string& s, Encoding enc)
+size_t nppcrypt::UserData::set(std::string& s, Encoding enc)
 {
     if(enc == Encoding::ascii) {
         data.Assign((const byte*)s.c_str(), s.size());
@@ -1209,7 +1209,7 @@ size_t crypt::UserData::set(std::string& s, Encoding enc)
     return data.size();
 }
 
-size_t crypt::UserData::set(const char* s, size_t length, Encoding enc)
+size_t nppcrypt::UserData::set(const char* s, size_t length, Encoding enc)
 {
     if (enc == Encoding::ascii) {
         data.Assign((const byte*)s, length);
@@ -1233,7 +1233,7 @@ size_t crypt::UserData::set(const char* s, size_t length, Encoding enc)
     return data.size();
 }
 
-size_t crypt::UserData::set(const byte* s, size_t length)
+size_t nppcrypt::UserData::set(const byte* s, size_t length)
 {
     if (s && length) {
         data.Assign(s, length);
@@ -1243,7 +1243,7 @@ size_t crypt::UserData::set(const byte* s, size_t length)
 
 
 
-bool crypt::UserData::random(size_t length, Restriction k, bool blocking)
+bool nppcrypt::UserData::random(size_t length, Restriction k, bool blocking)
 {
     if (length > 0 && length <= Constants::rand_char_max) {
         data.resize(length);
@@ -1316,7 +1316,7 @@ bool crypt::UserData::random(size_t length, Restriction k, bool blocking)
     return false;
 }
 
-bool crypt::UserData::zero(size_t length)
+bool nppcrypt::UserData::zero(size_t length)
 {
     if (length > 0 && length <= 4096) {
         data.Assign(length, 0);
@@ -1325,7 +1325,7 @@ bool crypt::UserData::zero(size_t length)
     return false;
 }
 
-void crypt::UserData::get(std::string& s, Encoding enc) const
+void nppcrypt::UserData::get(std::string& s, Encoding enc) const
 {
     if (data.size()) {
         if (enc == Encoding::ascii) {
@@ -1354,7 +1354,7 @@ void crypt::UserData::get(std::string& s, Encoding enc) const
     }
 }
 
-void crypt::UserData::get(secure_string& s, Encoding enc) const
+void nppcrypt::UserData::get(secure_string& s, Encoding enc) const
 {
     if (data.size()) {
         if (enc == Encoding::ascii) {
@@ -1383,14 +1383,14 @@ void crypt::UserData::get(secure_string& s, Encoding enc) const
     }
 }
 
-void crypt::UserData::clear()
+void nppcrypt::UserData::clear()
 {
     data.New(0);
 }
 
 // ===========================================================================================================================================================================================
 
-bool crypt::getCipherInfo(crypt::Cipher cipher, crypt::Mode mode, size_t& key_length, size_t& iv_length, size_t& block_size)
+bool nppcrypt::getCipherInfo(nppcrypt::Cipher cipher, nppcrypt::Mode mode, size_t& key_length, size_t& iv_length, size_t& block_size)
 {
     using namespace CryptoPP;
     switch (cipher)
@@ -1592,7 +1592,7 @@ bool crypt::getCipherInfo(crypt::Cipher cipher, crypt::Mode mode, size_t& key_le
     return true;
 }
 
-bool crypt::getHashInfo(Hash h, size_t& length, size_t& keylength)
+bool nppcrypt::getHashInfo(Hash h, size_t& length, size_t& keylength)
 {
     using namespace CryptoPP;
     keylength = 0;
@@ -1676,7 +1676,7 @@ bool crypt::getHashInfo(Hash h, size_t& length, size_t& keylength)
     return true;
 }
 
-void crypt::encrypt(const byte* in, size_t in_len, std::basic_string<byte>& buffer, const Options::Crypt& options, const UserData& password, InitData& init)
+void nppcrypt::encrypt(const byte* in, size_t in_len, std::basic_string<byte>& buffer, const Options::Crypt& options, const UserData& password, InitData& init)
 {
     using namespace CryptoPP;
 
@@ -1701,7 +1701,7 @@ void crypt::encrypt(const byte* in, size_t in_len, std::basic_string<byte>& buff
         ptSalt = init.salt.BytePtr();
     }
     // --------------------------- prepare iv & key vector
-    if (options.iv == crypt::IV::keyderivation) {
+    if (options.iv == nppcrypt::IV::keyderivation) {
         tKey.resize(key_len + iv_len);
     } else {
         tKey.resize(key_len);
@@ -1833,20 +1833,20 @@ void crypt::encrypt(const byte* in, size_t in_len, std::basic_string<byte>& buff
         }
     } catch (CryptoPP::Exception& exc) {
         throwError(exc.GetWhat());
-    } catch (crypt::Exception& exc) {
+    } catch (nppcrypt::Exception& exc) {
         throw exc;
     } catch (...) {
         throwError("encrypt: unexpected error.");
     }
  }
 
-void crypt::decrypt(const byte* in, size_t in_len, std::basic_string<byte>& buffer, const Options::Crypt& options, const UserData& password, InitData& init)
+void nppcrypt::decrypt(const byte* in, size_t in_len, std::basic_string<byte>& buffer, const Options::Crypt& options, const UserData& password, InitData& init)
 {
     if (!in || !in_len) {
         throwInvalid("decrypt: invalid input.");
     }
 
-    using namespace crypt;
+    using namespace nppcrypt;
     using namespace CryptoPP;
 
     SecByteBlock        tKey;
@@ -1859,7 +1859,7 @@ void crypt::decrypt(const byte* in, size_t in_len, std::basic_string<byte>& buff
 
     // --------------------------- prepare salt vector:
     if (options.key.salt_bytes > 0) {
-        if (options.key.algorithm == crypt::KeyDerivation::bcrypt && (options.key.salt_bytes != 16 || init.salt.size() != 16)) {
+        if (options.key.algorithm == nppcrypt::KeyDerivation::bcrypt && (options.key.salt_bytes != 16 || init.salt.size() != 16)) {
             throwInvalid("decrypt: bcrypt needs 16 byte salt!");
         }
         ptSalt = init.salt.BytePtr();
@@ -2000,14 +2000,14 @@ void crypt::decrypt(const byte* in, size_t in_len, std::basic_string<byte>& buff
         } else {
             throwError(exc.GetWhat());
         }
-    } catch (crypt::Exception& exc) {
+    } catch (nppcrypt::Exception& exc) {
         throw exc;
     } catch (...) {
         throwError("decrypt: unexpected error.");
     }
 }
 
-void crypt::hash(Options::Hash& options, std::basic_string<byte>& buffer, std::initializer_list<std::pair<const byte*, size_t>> in)
+void nppcrypt::hash(Options::Hash& options, std::basic_string<byte>& buffer, std::initializer_list<std::pair<const byte*, size_t>> in)
 {
     try {
         using namespace CryptoPP;
@@ -2035,22 +2035,22 @@ void crypt::hash(Options::Hash& options, std::basic_string<byte>& buffer, std::i
         buffer.clear();
         switch (options.encoding)
         {
-        case crypt::Encoding::ascii:
+        case nppcrypt::Encoding::ascii:
         {
             buffer.assign(digest.begin(), digest.end());
             break;
         }
-        case crypt::Encoding::base16:
+        case nppcrypt::Encoding::base16:
         {
             StringSource(&digest[0], digest.size(), true, new HexEncoder(new StringSinkTemplate<std::basic_string<byte>>(buffer)));
             break;
         }
-        case crypt::Encoding::base32:
+        case nppcrypt::Encoding::base32:
         {
             StringSource(&digest[0], digest.size(), true, new Base32Encoder(new StringSinkTemplate<std::basic_string<byte>>(buffer)));
             break;
         }
-        case crypt::Encoding::base64:
+        case nppcrypt::Encoding::base64:
         {
             StringSource(&digest[0], digest.size(), true, new Base64Encoder(new StringSinkTemplate<std::basic_string<byte>>(buffer)));
             break;
@@ -2061,7 +2061,7 @@ void crypt::hash(Options::Hash& options, std::basic_string<byte>& buffer, std::i
     }
 }
 
-void crypt::hash(Options::Hash& options, std::basic_string<byte>& buffer, const std::string& path)
+void nppcrypt::hash(Options::Hash& options, std::basic_string<byte>& buffer, const std::string& path)
 {
     try {
         using namespace CryptoPP;
@@ -2079,22 +2079,22 @@ void crypt::hash(Options::Hash& options, std::basic_string<byte>& buffer, const 
         buffer.clear();
         switch (options.encoding)
         {
-        case crypt::Encoding::ascii:
+        case nppcrypt::Encoding::ascii:
         {
             buffer.assign(digest.begin(), digest.end());
             break;
         }
-        case crypt::Encoding::base16:
+        case nppcrypt::Encoding::base16:
         {
             StringSource(&digest[0], digest.size(), true, new HexEncoder(new StringSinkTemplate<std::basic_string<byte>>(buffer)));
             break;
         }
-        case crypt::Encoding::base32:
+        case nppcrypt::Encoding::base32:
         {
             StringSource(&digest[0], digest.size(), true, new Base32Encoder(new StringSinkTemplate<std::basic_string<byte>>(buffer)));
             break;
         }
-        case crypt::Encoding::base64:
+        case nppcrypt::Encoding::base64:
         {
             StringSource(&digest[0], digest.size(), true, new Base64Encoder(new StringSinkTemplate<std::basic_string<byte>>(buffer)));
             break;
@@ -2105,7 +2105,7 @@ void crypt::hash(Options::Hash& options, std::basic_string<byte>& buffer, const 
     }
 }
 
-void crypt::shake128(const byte* in, size_t in_len, byte* out, size_t out_len)
+void nppcrypt::shake128(const byte* in, size_t in_len, byte* out, size_t out_len)
 {
     Keccak_HashInstance keccak_inst;
     if (Keccak_HashInitialize_SHAKE128(&keccak_inst) != 0) {
@@ -2122,10 +2122,10 @@ void crypt::shake128(const byte* in, size_t in_len, byte* out, size_t out_len)
     }
 }
 
-void crypt::convert(const byte* in, size_t in_len, std::basic_string<byte>& buffer, const Options::Convert& options, const EncodingAlphabet* base32_alphabet, const EncodingAlphabet* base64_alphabet)
+void nppcrypt::convert(const byte* in, size_t in_len, std::basic_string<byte>& buffer, const Options::Convert& options, const EncodingAlphabet* base32_alphabet, const EncodingAlphabet* base64_alphabet)
 {
     using namespace CryptoPP;
-    using namespace crypt;
+    using namespace nppcrypt;
 
     const std::string& s_eol = Strings::eol[(unsigned)options.eol];
     int linelength = options.linebreaks ? (int)options.linelength : 0;

--- a/src/crypt.h
+++ b/src/crypt.h
@@ -19,7 +19,7 @@ GNU General Public License for more details.
 #include <string>
 #include "cryptopp/secblock.h"
 
-namespace crypt
+namespace nppcrypt
 {
     typedef CryptoPP::byte byte;
     typedef std::basic_string<char, std::char_traits<char>, CryptoPP::AllocatorWithCleanup<char> > secure_string;
@@ -185,9 +185,9 @@ namespace crypt
         {
             Crypt() : cipher(Cipher::rijndael), mode(Mode::gcm), iv(IV::random), aad(true) {};
 
-            crypt::Cipher           cipher;
-            crypt::Mode             mode;
-            crypt::IV               iv;
+            nppcrypt::Cipher           cipher;
+            nppcrypt::Mode             mode;
+            nppcrypt::IV               iv;
             bool                    aad;
 
             struct Key
@@ -202,8 +202,8 @@ namespace crypt
 
             struct Encoding
             {
-                Encoding() : enc(crypt::Encoding::base64), linelength(128), linebreaks(true), eol(EOL::windows), uppercase(true) {};
-                crypt::Encoding     enc;
+                Encoding() : enc(nppcrypt::Encoding::base64), linelength(128), linebreaks(true), eol(EOL::windows), uppercase(true) {};
+                nppcrypt::Encoding     enc;
                 size_t              linelength;
                 bool                linebreaks;
                 EOL                 eol;
@@ -214,21 +214,21 @@ namespace crypt
 
         struct Hash
         {
-            Hash() : encoding(crypt::Encoding::base16), algorithm(crypt::Hash::md5), use_key(false), digest_length(16) {};
+            Hash() : encoding(nppcrypt::Encoding::base16), algorithm(nppcrypt::Hash::md5), use_key(false), digest_length(16) {};
 
-            crypt::Hash             algorithm;
+            nppcrypt::Hash             algorithm;
             size_t                  digest_length;
-            crypt::Encoding         encoding;
+            nppcrypt::Encoding         encoding;
             bool                    use_key;
             UserData                key;
         };
 
         struct Convert
         {
-            Convert() : from(crypt::Encoding::ascii), to(crypt::Encoding::base64), linebreaks(true), eol(EOL::windows), linelength(64), uppercase(true) {};
+            Convert() : from(nppcrypt::Encoding::ascii), to(nppcrypt::Encoding::base64), linebreaks(true), eol(EOL::windows), linelength(64), uppercase(true) {};
 
-            crypt::Encoding         from;
-            crypt::Encoding         to;
+            nppcrypt::Encoding         from;
+            nppcrypt::Encoding         to;
             bool                    linebreaks;
             EOL                     eol;
             bool                    uppercase;
@@ -238,7 +238,7 @@ namespace crypt
 
     /* ---------------------------------------------------------------------------------------------------------------------------------- */
     
-    bool getCipherInfo(crypt::Cipher cipher, crypt::Mode mode, size_t& key_length, size_t& iv_length, size_t& block_size);
+    bool getCipherInfo(nppcrypt::Cipher cipher, nppcrypt::Mode mode, size_t& key_length, size_t& iv_length, size_t& block_size);
     bool getHashInfo(Hash h, size_t& length, size_t& keylength);
     void encrypt(const byte* in, size_t in_len, std::basic_string<byte>& buffer, const Options::Crypt& options, const UserData& password, InitData& init);
     void decrypt(const byte* in, size_t in_len, std::basic_string<byte>& buffer, const Options::Crypt& options, const UserData& password, InitData& init);

--- a/src/crypt_help.cpp
+++ b/src/crypt_help.cpp
@@ -31,13 +31,13 @@ T ipow(T base, T exp)
     return result;
 }
 
-using namespace crypt;
+using namespace nppcrypt;
 
 // ----------------------------- PROPERTIES -------------------------------------------------------------------------------------------------------------------------------------------------------
 
 enum { B4 = 1, B8 = 2, B12 = 4, B16 = 8, B20 = 16, B24 = 32, B28 = 64, B32 = 128, B36 = 256, B40 = 512, B44 = 1024, B48 = 2048, B52 = 4096, B56 = 8192, B60 = 16384, B64 = 32768 };
 
-static const unsigned int cipher_properties[unsigned(crypt::Cipher::COUNT)] =
+static const unsigned int cipher_properties[unsigned(nppcrypt::Cipher::COUNT)] =
 {
     /* threeway         */ BLOCK | WEAK,
     /* aria             */ BLOCK | EAX | CCM | GCM,
@@ -87,7 +87,7 @@ static const unsigned int cipher_properties[unsigned(crypt::Cipher::COUNT)] =
 };
 
 /* { Start, Stepsize, Count } in Bytes */
-static const unsigned int cipher_keys[unsigned(crypt::Cipher::COUNT)][3] =
+static const unsigned int cipher_keys[unsigned(nppcrypt::Cipher::COUNT)][3] =
 {
     /* threeway         */ {12, 0, 1},
     /* aria             */ {16, 8, 3},
@@ -136,7 +136,7 @@ static const unsigned int cipher_keys[unsigned(crypt::Cipher::COUNT)][3] =
     /* xtea             */ {16, 0, 1}
 };
 
-static const unsigned int hash_properties[unsigned(crypt::Hash::COUNT)] =
+static const unsigned int hash_properties[unsigned(nppcrypt::Hash::COUNT)] =
 {
     /* adler32          */ WEAK,
     /* blake2b          */ KEY_SUPPORT,
@@ -158,7 +158,7 @@ static const unsigned int hash_properties[unsigned(crypt::Hash::COUNT)] =
     /* whirlpool        */ HMAC_SUPPORT
 };
 
-static const unsigned int hash_digests[unsigned(crypt::Hash::COUNT)] =
+static const unsigned int hash_digests[unsigned(nppcrypt::Hash::COUNT)] =
 {
     /* adler32          */ B4,
     /* blake2b          */ B16 | B28 | B32 | B48 | B64,
@@ -180,7 +180,7 @@ static const unsigned int hash_digests[unsigned(crypt::Hash::COUNT)] =
     /* whirlpool        */ B64,
 };
 
-/* { startindex , endindex } of crypt::Cipher */
+/* { startindex , endindex } of nppcrypt::Cipher */
 #define CIPHER_CAT_COUNT 4
 static const int cipher_categories[4][2] =
 {
@@ -251,52 +251,52 @@ int searchStringArray(const char* s, const char** a, size_t a_length)
     return -1;
 }
 
-const char* crypt::help::getString(crypt::Cipher cipher)
+const char* nppcrypt::help::getString(nppcrypt::Cipher cipher)
 {
     return Strings::cipher[static_cast<int>(cipher)];
 }
 
-const char* crypt::help::getString(crypt::Mode mode)
+const char* nppcrypt::help::getString(nppcrypt::Mode mode)
 {
     return Strings::mode[static_cast<int>(mode)];
 }
 
-const char*  crypt::help::getString(crypt::Encoding enc)
+const char*  nppcrypt::help::getString(nppcrypt::Encoding enc)
 {
     return Strings::encoding[static_cast<int>(enc)];
 }
 
-const char* crypt::help::getString(crypt::KeyDerivation k)
+const char* nppcrypt::help::getString(nppcrypt::KeyDerivation k)
 {
     return Strings::key_algo[static_cast<int>(k)];
 }
 
-const char* crypt::help::getString(crypt::IV iv)
+const char* nppcrypt::help::getString(nppcrypt::IV iv)
 {
     return Strings::iv[static_cast<int>(iv)];
 }
 
-const char* crypt::help::getString(crypt::Hash h)
+const char* nppcrypt::help::getString(nppcrypt::Hash h)
 {
     return Strings::hash[static_cast<int>(h)];
 }
 
-const char* crypt::help::getString(UserData::Restriction r)
+const char* nppcrypt::help::getString(UserData::Restriction r)
 {
     return Strings::random_restriction[static_cast<int>(r)];
 }
 
-const char* crypt::help::getString(crypt::EOL eol)
+const char* nppcrypt::help::getString(nppcrypt::EOL eol)
 {
     return Strings::eol[static_cast<int>(eol)];
 }
 
-const char* crypt::help::getString(bool v)
+const char* nppcrypt::help::getString(bool v)
 {
     return Strings::boolean[v ? 0 : 1];
 }
 
-bool crypt::help::getCipher(const char* s, crypt::Cipher& c)
+bool nppcrypt::help::getCipher(const char* s, nppcrypt::Cipher& c)
 {
     int index = searchStringArray(s, Strings::cipher, (size_t)Cipher::COUNT);
     if (index >= 0) {
@@ -307,7 +307,7 @@ bool crypt::help::getCipher(const char* s, crypt::Cipher& c)
     }
 }
 
-bool crypt::help::getCipherMode(const char* s, crypt::Mode& m)
+bool nppcrypt::help::getCipherMode(const char* s, nppcrypt::Mode& m)
 {
     int index = searchStringArray(s, Strings::mode, (size_t)Mode::COUNT);
     if (index >= 0) {
@@ -318,7 +318,7 @@ bool crypt::help::getCipherMode(const char* s, crypt::Mode& m)
     }
 }
 
-bool crypt::help::getKeyDerivation(const char*s, KeyDerivation& v)
+bool nppcrypt::help::getKeyDerivation(const char*s, KeyDerivation& v)
 {
     int index = searchStringArray(s, Strings::key_algo, (size_t)KeyDerivation::COUNT);
     if (index >= 0) {
@@ -329,7 +329,7 @@ bool crypt::help::getKeyDerivation(const char*s, KeyDerivation& v)
     }
 }
 
-bool crypt::help::getIVMode(const char* s, crypt::IV& iv)
+bool nppcrypt::help::getIVMode(const char* s, nppcrypt::IV& iv)
 {
     int index = searchStringArray(s, Strings::iv, (size_t)IV::COUNT);
     if (index >= 0) {
@@ -340,7 +340,7 @@ bool crypt::help::getIVMode(const char* s, crypt::IV& iv)
     }
 }
 
-bool crypt::help::getEncoding(const char* s, crypt::Encoding& e)
+bool nppcrypt::help::getEncoding(const char* s, nppcrypt::Encoding& e)
 {
     int index = searchStringArray(s, Strings::encoding, (size_t)Encoding::COUNT);
     if (index >= 0) {
@@ -351,7 +351,7 @@ bool crypt::help::getEncoding(const char* s, crypt::Encoding& e)
     }
 }
 
-bool crypt::help::getRandomRestriction(const char* s, UserData::Restriction& r)
+bool nppcrypt::help::getRandomRestriction(const char* s, UserData::Restriction& r)
 {
     int index = searchStringArray(s, Strings::random_restriction, (size_t)UserData::Restriction::COUNT);
     if (index >= 0) {
@@ -362,7 +362,7 @@ bool crypt::help::getRandomRestriction(const char* s, UserData::Restriction& r)
     }
 }
 
-bool crypt::help::getEOL(const char* s, crypt::EOL& eol)
+bool nppcrypt::help::getEOL(const char* s, nppcrypt::EOL& eol)
 {
     int index = searchStringArray(s, Strings::eol, (size_t)EOL::COUNT);
     if (index >= 0) {
@@ -373,7 +373,7 @@ bool crypt::help::getEOL(const char* s, crypt::EOL& eol)
     }
 }
 
-bool crypt::help::getHash(const char* s, Hash& h)
+bool nppcrypt::help::getHash(const char* s, Hash& h)
 {
     int index = searchStringArray(s, Strings::hash, (size_t)Hash::COUNT);
     if (index >= 0) {
@@ -384,7 +384,7 @@ bool crypt::help::getHash(const char* s, Hash& h)
     }
 }
 
-bool crypt::help::getUnsigned(const char* s, size_t& i)
+bool nppcrypt::help::getUnsigned(const char* s, size_t& i)
 {
     if (s && strlen(s) <= 10) {
         i = (size_t)std::atoi(s);
@@ -393,7 +393,7 @@ bool crypt::help::getUnsigned(const char* s, size_t& i)
     return false;
 }
 
-bool crypt::help::getInteger(const char* s, int& i, bool log2)
+bool nppcrypt::help::getInteger(const char* s, int& i, bool log2)
 {
     if (s && strlen(s) <= 10) {
         if (log2) {
@@ -410,7 +410,7 @@ bool crypt::help::getInteger(const char* s, int& i, bool log2)
     return false;
 }
 
-bool crypt::help::getBoolean(const char* s, bool& b)
+bool nppcrypt::help::getBoolean(const char* s, bool& b)
 {
     if (s) {
         size_t len = strlen(s);
@@ -425,7 +425,7 @@ bool crypt::help::getBoolean(const char* s, bool& b)
     return false;
 }
 
-void crypt::help::validate(Options::Crypt options, bool exceptions)
+void nppcrypt::help::validate(Options::Crypt options, bool exceptions)
 {
     // ---------- cipher mode
     if (!checkProperty(options.cipher, STREAM) && !checkCipherMode(options.cipher, options.mode)) {
@@ -451,7 +451,7 @@ void crypt::help::validate(Options::Crypt options, bool exceptions)
     switch (options.key.algorithm) {
     case KeyDerivation::pbkdf2:
     {
-        if (options.key.options[0] < 0 || options.key.options[0] >= (int)crypt::Hash::COUNT || !checkProperty((crypt::Hash)options.key.options[0], HMAC_SUPPORT)) {
+        if (options.key.options[0] < 0 || options.key.options[0] >= (int)nppcrypt::Hash::COUNT || !checkProperty((nppcrypt::Hash)options.key.options[0], HMAC_SUPPORT)) {
             if (exceptions) {
                 throwInvalid(invalid_pbkdf2);
             } else {
@@ -459,54 +459,54 @@ void crypt::help::validate(Options::Crypt options, bool exceptions)
                 options.key.options[1] = Constants::pbkdf2_default_hash_digest;
             }
         }
-        if (options.key.options[1] != 0 && !crypt::help::checkHashDigest((Hash)options.key.options[0], (unsigned int)options.key.options[1])) {
+        if (options.key.options[1] != 0 && !nppcrypt::help::checkHashDigest((Hash)options.key.options[0], (unsigned int)options.key.options[1])) {
             if (exceptions) {
                 throwInvalid(invalid_pbkdf2);
             } else {
                 options.key.options[1] = 0;
             }
         }
-        if (options.key.options[2] < crypt::Constants::pbkdf2_iter_min || options.key.options[2] > crypt::Constants::pbkdf2_iter_max) {
+        if (options.key.options[2] < nppcrypt::Constants::pbkdf2_iter_min || options.key.options[2] > nppcrypt::Constants::pbkdf2_iter_max) {
             if (exceptions) {
                 throwInvalid(invalid_pbkdf2);
             } else {
-                options.key.options[2] = crypt::Constants::pbkdf2_iter_default;
+                options.key.options[2] = nppcrypt::Constants::pbkdf2_iter_default;
             }
         }
         break;
     }
     case KeyDerivation::bcrypt:
     {
-        if (options.key.options[0] < crypt::Constants::bcrypt_iter_min || options.key.options[0] > crypt::Constants::bcrypt_iter_max) {
+        if (options.key.options[0] < nppcrypt::Constants::bcrypt_iter_min || options.key.options[0] > nppcrypt::Constants::bcrypt_iter_max) {
             if (exceptions) {
                 throwInvalid(invalid_bcrypt);
             } else {
-                options.key.options[0] = crypt::Constants::bcrypt_iter_default;
+                options.key.options[0] = nppcrypt::Constants::bcrypt_iter_default;
             }
         }
         break;
     }
     case KeyDerivation::scrypt:
     {
-        if (options.key.options[0] < crypt::Constants::scrypt_N_min || options.key.options[0] > crypt::Constants::scrypt_N_max) {
+        if (options.key.options[0] < nppcrypt::Constants::scrypt_N_min || options.key.options[0] > nppcrypt::Constants::scrypt_N_max) {
             if (exceptions) {
                 throwInvalid(invalid_scrypt);
             } else {
-                options.key.options[0] = crypt::Constants::scrypt_N_default;
+                options.key.options[0] = nppcrypt::Constants::scrypt_N_default;
             }
         }
-        if (options.key.options[1] < crypt::Constants::scrypt_r_min || options.key.options[1] > crypt::Constants::scrypt_r_max) {
+        if (options.key.options[1] < nppcrypt::Constants::scrypt_r_min || options.key.options[1] > nppcrypt::Constants::scrypt_r_max) {
             if (exceptions) {
                 throwInvalid(invalid_scrypt);
             } else {
-                options.key.options[1] = crypt::Constants::scrypt_r_default;
+                options.key.options[1] = nppcrypt::Constants::scrypt_r_default;
             }
         }
-        if (options.key.options[2] < crypt::Constants::scrypt_p_min || options.key.options[2] > crypt::Constants::scrypt_p_max) {
+        if (options.key.options[2] < nppcrypt::Constants::scrypt_p_min || options.key.options[2] > nppcrypt::Constants::scrypt_p_max) {
             if (exceptions) {
                 throwInvalid(invalid_scrypt);
             } else {
-                options.key.options[2] = crypt::Constants::scrypt_p_default;
+                options.key.options[2] = nppcrypt::Constants::scrypt_p_default;
             }
         }
         break;
@@ -537,7 +537,7 @@ void crypt::help::validate(Options::Crypt options, bool exceptions)
     }
 }
 
-void crypt::help::validate(Options::Hash options, bool exceptions)
+void nppcrypt::help::validate(Options::Hash options, bool exceptions)
 {
     if (!help::checkHashDigest(options.algorithm, (unsigned int)options.digest_length)) {
         if (exceptions) {
@@ -547,14 +547,14 @@ void crypt::help::validate(Options::Hash options, bool exceptions)
         }
     }
     if (options.use_key) {
-        if (!help::checkProperty(options.algorithm, crypt::HMAC_SUPPORT) && !help::checkProperty(options.algorithm, crypt::KEY_SUPPORT)) {
+        if (!help::checkProperty(options.algorithm, nppcrypt::HMAC_SUPPORT) && !help::checkProperty(options.algorithm, nppcrypt::KEY_SUPPORT)) {
             if (exceptions) {
                 throwInvalid(hash_without_keysupport);
             } else {
                 options.algorithm = Hash::sha3;
             }
         }
-    } else if (help::checkProperty(options.algorithm, crypt::KEY_REQUIRED)) {
+    } else if (help::checkProperty(options.algorithm, nppcrypt::KEY_REQUIRED)) {
         if (exceptions) {
             throwInvalid(hash_requires_key);
         } else {
@@ -563,7 +563,7 @@ void crypt::help::validate(Options::Hash options, bool exceptions)
     }
 }
 
-void crypt::help::validate(Options::Convert options, bool exceptions)
+void nppcrypt::help::validate(Options::Convert options, bool exceptions)
 {
     if (options.from == options.to) {
         if (exceptions) {
@@ -590,7 +590,7 @@ void crypt::help::validate(Options::Convert options, bool exceptions)
     }
 }
 
-crypt::Mode crypt::help::getModeByIndex(crypt::Cipher cipher, int index)
+nppcrypt::Mode nppcrypt::help::getModeByIndex(nppcrypt::Cipher cipher, int index)
 {
     if (index >= 0 && index < int(Mode::eax)) {
         return Mode(index);
@@ -610,7 +610,7 @@ crypt::Mode crypt::help::getModeByIndex(crypt::Cipher cipher, int index)
     return Mode::cbc;
 }
 
-int crypt::help::getModeIndex(crypt::Cipher cipher, crypt::Mode mode)
+int nppcrypt::help::getModeIndex(nppcrypt::Cipher cipher, nppcrypt::Mode mode)
 {
     if (mode == Mode::eax) {
         if ((cipher_properties[int(cipher)] & EAX) == EAX) {
@@ -630,7 +630,7 @@ int crypt::help::getModeIndex(crypt::Cipher cipher, crypt::Mode mode)
     return -1;
 }
 
-int crypt::help::getCipherCategory(Cipher cipher)
+int nppcrypt::help::getCipherCategory(Cipher cipher)
 {
     for (int i = CIPHER_CAT_COUNT - 1; i >= 0; i--) {
         if ((int)cipher >= cipher_categories[i][0]) {
@@ -640,16 +640,16 @@ int crypt::help::getCipherCategory(Cipher cipher)
     return -1;
 }
 
-crypt::Cipher crypt::help::getCipherByIndex(size_t category, size_t index)
+nppcrypt::Cipher nppcrypt::help::getCipherByIndex(size_t category, size_t index)
 {
-    if (category >= CIPHER_CAT_COUNT || cipher_categories[category][0] + index >= (size_t)crypt::Cipher::COUNT) {
+    if (category >= CIPHER_CAT_COUNT || cipher_categories[category][0] + index >= (size_t)nppcrypt::Cipher::COUNT) {
         return Cipher::rijndael;
     } else {
         return (Cipher)(cipher_categories[category][0] + index);
     }
 }
 
-int crypt::help::getCipherIndex(Cipher cipher)
+int nppcrypt::help::getCipherIndex(Cipher cipher)
 {
     for (int i = 0; i < CIPHER_CAT_COUNT; i++) {
         if ((int)cipher <= cipher_categories[i][1]) {
@@ -659,12 +659,12 @@ int crypt::help::getCipherIndex(Cipher cipher)
     return -1;
 }
 
-size_t crypt::help::getCipherKeylengthByIndex(Cipher cipher, size_t index)
+size_t nppcrypt::help::getCipherKeylengthByIndex(Cipher cipher, size_t index)
 {
     return cipher_keys[(int)cipher][0] + index * cipher_keys[(int)cipher][1];
 }
 
-Hash crypt::help::getHashByIndex(size_t index, int filter)
+Hash nppcrypt::help::getHashByIndex(size_t index, int filter)
 {
     size_t h = 0;
     for (int i = 0; i < (int)Hash::COUNT; i++) {
@@ -682,7 +682,7 @@ Hash crypt::help::getHashByIndex(size_t index, int filter)
     return Hash::sha3;
 }
 
-int crypt::help::getHashIndex(Hash h, int filter)
+int nppcrypt::help::getHashIndex(Hash h, int filter)
 {
     int ret = 0;
     for (int i = 0; i < (int)Hash::COUNT; i++) {
@@ -700,7 +700,7 @@ int crypt::help::getHashIndex(Hash h, int filter)
     return -1;
 }
 
-size_t crypt::help::getHashDigestByIndex(Hash h, unsigned int index)
+size_t nppcrypt::help::getHashDigestByIndex(Hash h, unsigned int index)
 {
     unsigned int ind = 0;
     unsigned int i = 0;
@@ -717,7 +717,7 @@ size_t crypt::help::getHashDigestByIndex(Hash h, unsigned int index)
     return 0;
 }
 
-int crypt::help::getHashDigestIndex(Hash h, unsigned int digest)
+int nppcrypt::help::getHashDigestIndex(Hash h, unsigned int digest)
 {
     unsigned int ind = 0;
     unsigned int i = 0;
@@ -734,7 +734,7 @@ int crypt::help::getHashDigestIndex(Hash h, unsigned int digest)
     return 0;
 }
 
-bool crypt::help::checkCipherMode(crypt::Cipher cipher, crypt::Mode mode)
+bool nppcrypt::help::checkCipherMode(nppcrypt::Cipher cipher, nppcrypt::Mode mode)
 {
     if (mode == Mode::eax) {
         if ((cipher_properties[int(cipher)] & EAX) == EAX) {
@@ -754,7 +754,7 @@ bool crypt::help::checkCipherMode(crypt::Cipher cipher, crypt::Mode mode)
     return false;
 }
 
-bool crypt::help::checkProperty(crypt::Cipher cipher, int filter)
+bool nppcrypt::help::checkProperty(nppcrypt::Cipher cipher, int filter)
 {
     if ((unsigned)cipher >= (unsigned)Cipher::COUNT) {
         return false;
@@ -762,7 +762,7 @@ bool crypt::help::checkProperty(crypt::Cipher cipher, int filter)
     return ((cipher_properties[(unsigned)cipher] & filter) == filter);
 }
 
-bool crypt::help::checkProperty(crypt::Hash h, int filter)
+bool nppcrypt::help::checkProperty(nppcrypt::Hash h, int filter)
 {
     if ((unsigned)h >= (unsigned)Hash::COUNT) {
         return false;
@@ -770,7 +770,7 @@ bool crypt::help::checkProperty(crypt::Hash h, int filter)
     return ((hash_properties[(unsigned)h] & filter) == filter);
 }
 
-bool crypt::help::checkHashDigest(Hash h, unsigned int digest)
+bool nppcrypt::help::checkHashDigest(Hash h, unsigned int digest)
 {
     if (digest < 4 || digest > 128) {
         return false;
@@ -779,7 +779,7 @@ bool crypt::help::checkHashDigest(Hash h, unsigned int digest)
     return ((hash_digests[(unsigned)h] & x) == x);
 }
 
-bool crypt::help::checkCipherKeylength(Cipher cipher, size_t keylength)
+bool nppcrypt::help::checkCipherKeylength(Cipher cipher, size_t keylength)
 {
     for (size_t i = 0; i < cipher_keys[(int)cipher][2]; i++) {
         if (keylength == cipher_keys[(int)cipher][0] + cipher_keys[(int)cipher][1] * i) {
@@ -789,71 +789,71 @@ bool crypt::help::checkCipherKeylength(Cipher cipher, size_t keylength)
     return false;
 }
 
-const char* crypt::help::getHelpURL(crypt::Encoding enc)
+const char* nppcrypt::help::getHelpURL(nppcrypt::Encoding enc)
 {
     strcpy(Strings::help_url_wikipedia + Strings::help_url_wikipedia_len, Strings::encoding_info_url[unsigned(enc)]);
     return Strings::help_url_wikipedia;
 }
 
-const char* crypt::help::getHelpURL(crypt::Cipher cipher)
+const char* nppcrypt::help::getHelpURL(nppcrypt::Cipher cipher)
 {
     strcpy(Strings::help_url_wikipedia + Strings::help_url_wikipedia_len, Strings::cipher_info_url[unsigned(cipher)]);
     return Strings::help_url_wikipedia;
 }
 
-const char* crypt::help::getHelpURL(crypt::Hash h)
+const char* nppcrypt::help::getHelpURL(nppcrypt::Hash h)
 {
     strcpy(Strings::help_url_wikipedia + Strings::help_url_wikipedia_len, Strings::hash_info_url[unsigned(h)]);
     return Strings::help_url_wikipedia;
 }
 
-const char* crypt::help::getHelpURL(crypt::KeyDerivation k)
+const char* nppcrypt::help::getHelpURL(nppcrypt::KeyDerivation k)
 {
     strcpy(Strings::help_url_wikipedia + Strings::help_url_wikipedia_len, Strings::key_algo_info_url[unsigned(k)]);
     return Strings::help_url_wikipedia;
 }
 
-const char* crypt::help::getHelpURL(crypt::Mode m)
+const char* nppcrypt::help::getHelpURL(nppcrypt::Mode m)
 {
     strcpy(Strings::help_url_wikipedia + Strings::help_url_wikipedia_len, Strings::mode_info_url[unsigned(m)]);
     return Strings::help_url_wikipedia;
 }
 
-const char* crypt::help::getInfo(crypt::Cipher c)
+const char* nppcrypt::help::getInfo(nppcrypt::Cipher c)
 {
     return Strings::cipher_info[unsigned(c)];
 }
 
-const char* crypt::help::getInfo(crypt::Mode m)
+const char* nppcrypt::help::getInfo(nppcrypt::Mode m)
 {
     return Strings::mode_info[unsigned(m)];
 }
 
-const char* crypt::help::getInfo(crypt::Hash h)
+const char* nppcrypt::help::getInfo(nppcrypt::Hash h)
 {
     return Strings::hash_info[unsigned(h)];
 }
 
-const char* crypt::help::getInfo(crypt::IV iv)
+const char* nppcrypt::help::getInfo(nppcrypt::IV iv)
 {
     return Strings::iv_help[unsigned(iv)];
 }
 
-const char* crypt::help::getInfo(crypt::KeyDerivation k)
+const char* nppcrypt::help::getInfo(nppcrypt::KeyDerivation k)
 {
     return Strings::key_algo_info[unsigned(k)];
 }
 
-const char* crypt::help::getInfo(crypt::Encoding e)
+const char* nppcrypt::help::getInfo(nppcrypt::Encoding e)
 {
     return Strings::encoding_info[unsigned(e)];
 }
 
-crypt::help::CipherCategories::CipherCategories() : i(0)
+nppcrypt::help::CipherCategories::CipherCategories() : i(0)
 {
 }
 
-const char* crypt::help::CipherCategories::operator*() const
+const char* nppcrypt::help::CipherCategories::operator*() const
 {
     if (i >= 0) {
         return Strings::cipher_categories[i];
@@ -862,7 +862,7 @@ const char* crypt::help::CipherCategories::operator*() const
     }
 }
 
-crypt::help::CipherCategories& crypt::help::CipherCategories::operator++()
+nppcrypt::help::CipherCategories& nppcrypt::help::CipherCategories::operator++()
 {
     if (i != -1) {
         ++i;
@@ -873,7 +873,7 @@ crypt::help::CipherCategories& crypt::help::CipherCategories::operator++()
     return *this;
 }
 
-crypt::help::CipherNames::CipherNames(int category) : c(category), i(0)
+nppcrypt::help::CipherNames::CipherNames(int category) : c(category), i(0)
 {
     if (c < 0 || c >= CIPHER_CAT_COUNT) {
         i = -1;
@@ -882,7 +882,7 @@ crypt::help::CipherNames::CipherNames(int category) : c(category), i(0)
     }
 }
 
-const char* crypt::help::CipherNames::operator*() const
+const char* nppcrypt::help::CipherNames::operator*() const
 {
     if (i >= 0) {
         return Strings::cipher_label[i];
@@ -891,7 +891,7 @@ const char* crypt::help::CipherNames::operator*() const
     }
 }
 
-crypt::help::CipherNames& crypt::help::CipherNames::operator++()
+nppcrypt::help::CipherNames& nppcrypt::help::CipherNames::operator++()
 {
     if (i != -1) {
         ++i;
@@ -902,14 +902,14 @@ crypt::help::CipherNames& crypt::help::CipherNames::operator++()
     return *this;
 }
 
-crypt::help::CipherModes::CipherModes(crypt::Cipher c) : cipher_index((size_t)c), i(0)
+nppcrypt::help::CipherModes::CipherModes(nppcrypt::Cipher c) : cipher_index((size_t)c), i(0)
 {
     if ((cipher_properties[cipher_index] & STREAM) == STREAM) {
         i = -1;
     }
 }
 
-const char* crypt::help::CipherModes::operator*() const
+const char* nppcrypt::help::CipherModes::operator*() const
 {
     if (i >= 0) {
         return Strings::mode[i];
@@ -918,7 +918,7 @@ const char* crypt::help::CipherModes::operator*() const
     }
 }
 
-crypt::help::CipherModes& crypt::help::CipherModes::operator++()
+nppcrypt::help::CipherModes& nppcrypt::help::CipherModes::operator++()
 {
     if (i != -1) {
         ++i;
@@ -938,11 +938,11 @@ crypt::help::CipherModes& crypt::help::CipherModes::operator++()
     return *this;
 }
 
-crypt::help::CipherKeys::CipherKeys(crypt::Cipher c) : cipher_index((size_t)c), i(0)
+nppcrypt::help::CipherKeys::CipherKeys(nppcrypt::Cipher c) : cipher_index((size_t)c), i(0)
 {
 }
 
-int crypt::help::CipherKeys::operator*() const
+int nppcrypt::help::CipherKeys::operator*() const
 {
     if (i >= 0) {
         return cipher_keys[cipher_index][0] + i * cipher_keys[cipher_index][1];
@@ -951,7 +951,7 @@ int crypt::help::CipherKeys::operator*() const
     }
 }
 
-crypt::help::CipherKeys& crypt::help::CipherKeys::operator++()
+nppcrypt::help::CipherKeys& nppcrypt::help::CipherKeys::operator++()
 {
     ++i;
     if (i >= (int)cipher_keys[cipher_index][2]) {
@@ -960,12 +960,12 @@ crypt::help::CipherKeys& crypt::help::CipherKeys::operator++()
     return *this;
 }
 
-crypt::help::Hashnames::Hashnames(int filter) : f(filter), i(0)
+nppcrypt::help::Hashnames::Hashnames(int filter) : f(filter), i(0)
 {
     checkfilter();
 }
 
-const char* crypt::help::Hashnames::operator*() const
+const char* nppcrypt::help::Hashnames::operator*() const
 {
     if (i >= 0) {
         return Strings::hash_label[i];
@@ -974,7 +974,7 @@ const char* crypt::help::Hashnames::operator*() const
     }
 }
 
-crypt::help::Hashnames& crypt::help::Hashnames::operator++()
+nppcrypt::help::Hashnames& nppcrypt::help::Hashnames::operator++()
 {
     if (i != -1) {
         ++i;
@@ -983,7 +983,7 @@ crypt::help::Hashnames& crypt::help::Hashnames::operator++()
     return *this;
 }
 
-void crypt::help::Hashnames::checkfilter()
+void nppcrypt::help::Hashnames::checkfilter()
 {
     while (i < (int)Hash::COUNT) {
         if (((f & WEAK) == WEAK && (hash_properties[i] & WEAK) != WEAK) ||
@@ -1000,12 +1000,12 @@ void crypt::help::Hashnames::checkfilter()
     }
 }
 
-crypt::help::HashDigests::HashDigests(crypt::Hash h) : hash_index((size_t)h), i(0)
+nppcrypt::help::HashDigests::HashDigests(nppcrypt::Hash h) : hash_index((size_t)h), i(0)
 {
     getLength();
 }
 
-int crypt::help::HashDigests::operator*() const
+int nppcrypt::help::HashDigests::operator*() const
 {
     if (i >= 0) {
         return cur_length;
@@ -1014,14 +1014,14 @@ int crypt::help::HashDigests::operator*() const
     }
 }
 
-crypt::help::HashDigests& crypt::help::HashDigests::operator++()
+nppcrypt::help::HashDigests& nppcrypt::help::HashDigests::operator++()
 {
     ++i;
     getLength();
     return *this;
 }
 
-void crypt::help::HashDigests::getLength()
+void nppcrypt::help::HashDigests::getLength()
 {
     while (i < 16) {
         unsigned int x = ipow<unsigned int>(2, i);

--- a/src/crypt_help.h
+++ b/src/crypt_help.h
@@ -18,7 +18,7 @@ GNU General Public License for more details.
 
 #include "crypt.h"
 
-namespace crypt
+namespace nppcrypt
 {
     enum Properties { WEAK = 1, EAX = 2, CCM = 4, GCM = 8, BLOCK = 16, STREAM = 32, HMAC_SUPPORT = 64, KEY_SUPPORT = 128, KEY_REQUIRED = 256 };
 
@@ -104,7 +104,7 @@ namespace crypt
         class CipherModes
         {
         public:
-            CipherModes(crypt::Cipher c);
+            CipherModes(nppcrypt::Cipher c);
             CipherModes& operator++();
             const char* operator*() const;
         private:
@@ -115,7 +115,7 @@ namespace crypt
         class CipherKeys
         {
         public:
-            CipherKeys(crypt::Cipher c);
+            CipherKeys(nppcrypt::Cipher c);
             CipherKeys& operator++();
             int operator*() const;
         private:
@@ -138,7 +138,7 @@ namespace crypt
         class HashDigests
         {
         public:
-            HashDigests(crypt::Hash h);
+            HashDigests(nppcrypt::Hash h);
             HashDigests& operator++();
             int operator*() const;
         private:

--- a/src/cryptheader.cpp
+++ b/src/cryptheader.cpp
@@ -29,7 +29,7 @@ inline bool cmpchars(const char* s1, const char* s2, size_t len)
     return true;
 }
 
-bool CryptHeaderReader::parse(crypt::Options::Crypt& options, crypt::InitData& initdata, const crypt::byte* in, size_t in_len)
+bool CryptHeaderReader::parse(nppcrypt::Options::Crypt& options, nppcrypt::InitData& initdata, const nppcrypt::byte* in, size_t in_len)
 {
     if (in == NULL || in_len == 0) {
         return false;
@@ -48,7 +48,7 @@ bool CryptHeaderReader::parse(crypt::Options::Crypt& options, crypt::InitData& i
     size_t                  offset_body;
     tinyxml2::XMLError      xml_err;
     tinyxml2::XMLDocument   xml_doc;
-    crypt::Options::Crypt   t_options;
+    nppcrypt::Options::Crypt   t_options;
 
     // find header body start:
     while (offset < in_len - 12 && in[offset] != '>') {
@@ -95,8 +95,8 @@ bool CryptHeaderReader::parse(crypt::Options::Crypt& options, crypt::InitData& i
         if (hmac_length > 512) {
             throwInvalid(invalid_hmac_data);
         }
-        hmac_digest.set(pHMAC, hmac_length, crypt::Encoding::base64);
-        if (!crypt::help::getHash(xml_nppcrypt->Attribute("hmac-hash"), hmac.hash.algorithm)) {
+        hmac_digest.set(pHMAC, hmac_length, nppcrypt::Encoding::base64);
+        if (!nppcrypt::help::getHash(xml_nppcrypt->Attribute("hmac-hash"), hmac.hash.algorithm)) {
             throwInvalid(invalid_hmac_hash);
         }
         hmac.hash.digest_length = hmac_digest.size();
@@ -106,7 +106,7 @@ bool CryptHeaderReader::parse(crypt::Options::Crypt& options, crypt::InitData& i
         }
         hmac.enable = true;
         hmac.hash.use_key = true;
-        hmac.hash.encoding = crypt::Encoding::ascii;
+        hmac.hash.encoding = nppcrypt::Encoding::ascii;
     } else {
         hmac.enable = false;
     }
@@ -114,22 +114,22 @@ bool CryptHeaderReader::parse(crypt::Options::Crypt& options, crypt::InitData& i
     // encryption:
     tinyxml2::XMLElement* xml_crypt = xml_nppcrypt->FirstChildElement("encryption");
     if (xml_crypt) {
-        if (!crypt::help::getCipher(xml_crypt->Attribute("cipher"), t_options.cipher)) {
+        if (!nppcrypt::help::getCipher(xml_crypt->Attribute("cipher"), t_options.cipher)) {
             throwInvalid(invalid_cipher);
         }
-        if (!crypt::help::getUnsigned(xml_crypt->Attribute("key-length"), t_options.key.length)) {
+        if (!nppcrypt::help::getUnsigned(xml_crypt->Attribute("key-length"), t_options.key.length)) {
             throwInvalid(missing_keylength);
         }
-        if (crypt::help::checkProperty(t_options.cipher, crypt::BLOCK)) {
-            if (!crypt::help::getCipherMode(xml_crypt->Attribute("mode"), t_options.mode)) {
+        if (nppcrypt::help::checkProperty(t_options.cipher, nppcrypt::BLOCK)) {
+            if (!nppcrypt::help::getCipherMode(xml_crypt->Attribute("mode"), t_options.mode)) {
                 throwInvalid(invalid_mode);
             }
-            if ((t_options.mode == crypt::Mode::gcm || t_options.mode == crypt::Mode::ccm || t_options.mode == crypt::Mode::eax) &&
-                !crypt::help::getBoolean(xml_crypt->Attribute("aad"), t_options.aad)) {
+            if ((t_options.mode == nppcrypt::Mode::gcm || t_options.mode == nppcrypt::Mode::ccm || t_options.mode == nppcrypt::Mode::eax) &&
+                !nppcrypt::help::getBoolean(xml_crypt->Attribute("aad"), t_options.aad)) {
                 throwInvalid(invalid_aad_flag);
             }
         }
-        if (!crypt::help::getEncoding(xml_crypt->Attribute("encoding"), t_options.encoding.enc)) {
+        if (!nppcrypt::help::getEncoding(xml_crypt->Attribute("encoding"), t_options.encoding.enc)) {
             throwInvalid(invalid_encoding);
         }
     }
@@ -137,42 +137,42 @@ bool CryptHeaderReader::parse(crypt::Options::Crypt& options, crypt::InitData& i
     // key
     tinyxml2::XMLElement* xml_key = xml_nppcrypt->FirstChildElement("key");
     if (xml_key) {
-        if (!crypt::help::getKeyDerivation(xml_key->Attribute("algorithm"), t_options.key.algorithm)) {
+        if (!nppcrypt::help::getKeyDerivation(xml_key->Attribute("algorithm"), t_options.key.algorithm)) {
             throwInvalid(invalid_keyderivation);
         }
         switch (t_options.key.algorithm)
         {
-        case crypt::KeyDerivation::pbkdf2:
+        case nppcrypt::KeyDerivation::pbkdf2:
         {
-            crypt::Hash thash;
-            if (!crypt::help::getHash(xml_key->Attribute("hash"), thash)) {
+            nppcrypt::Hash thash;
+            if (!nppcrypt::help::getHash(xml_key->Attribute("hash"), thash)) {
                 throwInvalid(invalid_pbkdf2);
             }
             t_options.key.options[0] = static_cast<int>(thash);
-            if (!crypt::help::getInteger(xml_key->Attribute("digest-length"), t_options.key.options[1])) {
+            if (!nppcrypt::help::getInteger(xml_key->Attribute("digest-length"), t_options.key.options[1])) {
                 throwInvalid(invalid_pbkdf2);
             }
-            if (!crypt::help::getInteger(xml_key->Attribute("iterations"), t_options.key.options[2])) {
+            if (!nppcrypt::help::getInteger(xml_key->Attribute("iterations"), t_options.key.options[2])) {
                 throwInvalid(invalid_pbkdf2);
             }
             break;
         }
-        case crypt::KeyDerivation::bcrypt:
+        case nppcrypt::KeyDerivation::bcrypt:
         {
-            if (!crypt::help::getInteger(xml_key->Attribute("iterations"), t_options.key.options[0], true)) {
+            if (!nppcrypt::help::getInteger(xml_key->Attribute("iterations"), t_options.key.options[0], true)) {
                 throwInvalid(invalid_bcrypt);
             }
             break;
         }
-        case crypt::KeyDerivation::scrypt:
+        case nppcrypt::KeyDerivation::scrypt:
         {
-            if (!crypt::help::getInteger(xml_key->Attribute("N"), t_options.key.options[0], true)) {
+            if (!nppcrypt::help::getInteger(xml_key->Attribute("N"), t_options.key.options[0], true)) {
                 throwInvalid(invalid_scrypt);
             }
-            if (!crypt::help::getInteger(xml_key->Attribute("r"), t_options.key.options[1])) {
+            if (!nppcrypt::help::getInteger(xml_key->Attribute("r"), t_options.key.options[1])) {
                 throwInvalid(invalid_scrypt);
             }
-            if (!crypt::help::getInteger(xml_key->Attribute("p"), t_options.key.options[2])) {
+            if (!nppcrypt::help::getInteger(xml_key->Attribute("p"), t_options.key.options[2])) {
                 throwInvalid(invalid_scrypt);
             }
             break;
@@ -181,10 +181,10 @@ bool CryptHeaderReader::parse(crypt::Options::Crypt& options, crypt::InitData& i
         const char* pSalt = xml_key->Attribute("salt");
         if (pSalt) {
             size_t t_len = strlen(pSalt);
-            if (t_len > 2 * crypt::Constants::salt_max) {
+            if (t_len > 2 * nppcrypt::Constants::salt_max) {
                 throwInvalid(invalid_salt);
             }
-            initdata.salt.set(pSalt, t_len, crypt::Encoding::base64);
+            initdata.salt.set(pSalt, t_len, nppcrypt::Encoding::base64);
             t_options.key.salt_bytes = initdata.salt.size();
         } else {
             t_options.key.salt_bytes = 0;
@@ -202,8 +202,8 @@ bool CryptHeaderReader::parse(crypt::Options::Crypt& options, crypt::InitData& i
         if (iv_len > 2048) {
             throwInvalid(invalid_iv);
         }
-        initdata.iv.set(pIV, iv_len, crypt::Encoding::base64);
-        if (!crypt::help::getIVMode(xml_iv->Attribute("method"), t_options.iv)) {
+        initdata.iv.set(pIV, iv_len, nppcrypt::Encoding::base64);
+        if (!nppcrypt::help::getIVMode(xml_iv->Attribute("method"), t_options.iv)) {
             throwInvalid(invalid_iv);
         }
     }
@@ -219,7 +219,7 @@ bool CryptHeaderReader::parse(crypt::Options::Crypt& options, crypt::InitData& i
         if (tag_len > 2048) {
             throwInvalid(invalid_tag);
         }
-        initdata.tag.set(pTag, tag_len, crypt::Encoding::base64);
+        initdata.tag.set(pTag, tag_len, nppcrypt::Encoding::base64);
     }
 
     // setup encrypted data pointer
@@ -239,17 +239,17 @@ bool CryptHeaderReader::parse(crypt::Options::Crypt& options, crypt::InitData& i
         if (encrypted.start[i] == '\r' && encrypted.start[i + 1] == '\n')   {
             t_options.encoding.linebreaks = true;
             t_options.encoding.linelength = i;
-            t_options.encoding.eol = crypt::EOL::windows;
+            t_options.encoding.eol = nppcrypt::EOL::windows;
             break;
         } else if (encrypted.start[i] == '\n') {
             t_options.encoding.linebreaks = true;
             t_options.encoding.linelength = i;
-            t_options.encoding.eol = crypt::EOL::unix;
+            t_options.encoding.eol = nppcrypt::EOL::unix;
             break;
         }
     }
     // check if uppercase or lowercase
-    if (t_options.encoding.enc == crypt::Encoding::base16 || t_options.encoding.enc == crypt::Encoding::base32) {
+    if (t_options.encoding.enc == nppcrypt::Encoding::base16 || t_options.encoding.enc == nppcrypt::Encoding::base32) {
         for (size_t i = 0; i < encrypted.length - 1; i++) {
             if (std::isalpha((int)*(encrypted.start + i))) {
                 t_options.encoding.uppercase = (std::isupper((int)*(encrypted.start + i)) == 0) ? false : true;
@@ -261,9 +261,9 @@ bool CryptHeaderReader::parse(crypt::Options::Crypt& options, crypt::InitData& i
     }
 
     // validate options
-    crypt::help::validate(t_options);
+    nppcrypt::help::validate(t_options);
     if (hmac.enable) {
-        crypt::help::validate(hmac.hash);
+        nppcrypt::help::validate(hmac.hash);
     }
 
     options.aad = t_options.aad;
@@ -279,12 +279,12 @@ bool CryptHeaderReader::parse(crypt::Options::Crypt& options, crypt::InitData& i
 bool CryptHeaderReader::checkHMAC()
 {
     if (hmac.enable) {
-        std::basic_string<crypt::byte> buf;
-        crypt::hash(hmac.hash, buf, { { body.start, body.length },{ encrypted.start, encrypted.length } });
+        std::basic_string<nppcrypt::byte> buf;
+        nppcrypt::hash(hmac.hash, buf, { { body.start, body.length },{ encrypted.start, encrypted.length } });
         if (buf.size() != hmac_digest.size()) {
             return false;
         }
-        const crypt::byte* pDigest = hmac_digest.BytePtr();
+        const nppcrypt::byte* pDigest = hmac_digest.BytePtr();
         for (size_t i = 0; i < buf.size(); i++) {
             if (buf[i] != *(pDigest + i)) {
                 return false;
@@ -298,13 +298,13 @@ bool CryptHeaderReader::checkHMAC()
 
 // ====================================================================================================================================================================
 
-void CryptHeaderWriter::create(const crypt::Options::Crypt& options, const crypt::InitData& initdata, const crypt::byte* data, size_t data_length)
+void CryptHeaderWriter::create(const nppcrypt::Options::Crypt& options, const nppcrypt::InitData& initdata, const nppcrypt::byte* data, size_t data_length)
 {
     std::ostringstream      out;
     size_t                  body_start;
     size_t                  body_end;
     size_t                  hmac_offset;
-    crypt::secure_string    temp_s;
+    nppcrypt::secure_string    temp_s;
 
     if (!data || !data_length) {
         throwError(header_write_failed);
@@ -312,7 +312,7 @@ void CryptHeaderWriter::create(const crypt::Options::Crypt& options, const crypt
 
     static const char win[] = { '\r', '\n', 0 };
     const char* linebreak;
-    if (options.encoding.eol == crypt::EOL::windows) {
+    if (options.encoding.eol == nppcrypt::EOL::windows) {
         linebreak = win;
     } else {
         linebreak = &win[1];
@@ -322,10 +322,10 @@ void CryptHeaderWriter::create(const crypt::Options::Crypt& options, const crypt
     if (hmac.enable) {
         size_t hmac_length = hmac.hash.digest_length;
         size_t key_length;
-        if (!crypt::getHashInfo(hmac.hash.algorithm, hmac_length, key_length)) {
+        if (!nppcrypt::getHashInfo(hmac.hash.algorithm, hmac_length, key_length)) {
             throwInvalid(invalid_hmac_hash);
         }
-        out << " hmac-hash=\"" << crypt::help::getString(hmac.hash.algorithm) << "\"";
+        out << " hmac-hash=\"" << nppcrypt::help::getString(hmac.hash.algorithm) << "\"";
         if (hmac.keypreset_id >= 0) {
             out << " hmac-key=\"" << hmac.keypreset_id << "\"";
         }
@@ -337,48 +337,48 @@ void CryptHeaderWriter::create(const crypt::Options::Crypt& options, const crypt
     body_start = static_cast<size_t>(out.tellp()); 
     out << linebreak;   
     // <encryption>
-    out << "<encryption cipher=\"" << crypt::help::getString(options.cipher) << "\" key-length=\"" << options.key.length << "\"";
-    if (!crypt::help::checkProperty(options.cipher, crypt::STREAM)) {
-        out << " mode=\"" << crypt::help::getString(options.mode) << "\"";
-        if (options.mode == crypt::Mode::gcm || options.mode == crypt::Mode::ccm || options.mode == crypt::Mode::eax) {
-            out << " aad=\"" << crypt::help::getString(options.aad) << "\"";
+    out << "<encryption cipher=\"" << nppcrypt::help::getString(options.cipher) << "\" key-length=\"" << options.key.length << "\"";
+    if (!nppcrypt::help::checkProperty(options.cipher, nppcrypt::STREAM)) {
+        out << " mode=\"" << nppcrypt::help::getString(options.mode) << "\"";
+        if (options.mode == nppcrypt::Mode::gcm || options.mode == nppcrypt::Mode::ccm || options.mode == nppcrypt::Mode::eax) {
+            out << " aad=\"" << nppcrypt::help::getString(options.aad) << "\"";
         }
     }
-    out << " encoding=\"" << crypt::help::getString(options.encoding.enc) << "\" />" << linebreak;
+    out << " encoding=\"" << nppcrypt::help::getString(options.encoding.enc) << "\" />" << linebreak;
     // <key>
-    out << "<key algorithm=\"" << crypt::help::getString(options.key.algorithm);
+    out << "<key algorithm=\"" << nppcrypt::help::getString(options.key.algorithm);
     switch (options.key.algorithm)
     {
-    case crypt::KeyDerivation::pbkdf2:
+    case nppcrypt::KeyDerivation::pbkdf2:
     {
-        out << "\" hash=\"" << crypt::help::getString((crypt::Hash)options.key.options[0]) << "\" digest-length=\"" << options.key.options[1] << "\" iterations=\"" << options.key.options[2] << "\" ";
+        out << "\" hash=\"" << nppcrypt::help::getString((nppcrypt::Hash)options.key.options[0]) << "\" digest-length=\"" << options.key.options[1] << "\" iterations=\"" << options.key.options[2] << "\" ";
         break;
     }
-    case crypt::KeyDerivation::bcrypt:
+    case nppcrypt::KeyDerivation::bcrypt:
     {
         out << "\" iterations=\"" << static_cast<size_t>(std::pow(2, options.key.options[0])) << "\" ";
         break;
     }
-    case crypt::KeyDerivation::scrypt:
+    case nppcrypt::KeyDerivation::scrypt:
     {
         out << "\" N=\"" << static_cast<size_t>(std::pow(2, options.key.options[0])) << "\" r=\"" << options.key.options[1] << "\" p=\"" << options.key.options[2] << "\" ";
         break;
     }
     }
     if (options.key.salt_bytes > 0) {
-        initdata.salt.get(temp_s, crypt::Encoding::base64);
+        initdata.salt.get(temp_s, nppcrypt::Encoding::base64);
         out << "salt=\"" << temp_s << "\" ";
     }
     out << "/>" << linebreak;
     //<iv> and <tag>
     bool add_linebreak = false;
     if (initdata.iv.size() > 0) {
-        initdata.iv.get(temp_s, crypt::Encoding::base64);
-        out << "<iv value=\"" << temp_s << "\" method=\"" << crypt::help::getString(options.iv) << "\" />";
+        initdata.iv.get(temp_s, nppcrypt::Encoding::base64);
+        out << "<iv value=\"" << temp_s << "\" method=\"" << nppcrypt::help::getString(options.iv) << "\" />";
         add_linebreak = true;
     }
     if (initdata.tag.size() > 0) {
-        initdata.tag.get(temp_s, crypt::Encoding::base64);
+        initdata.tag.get(temp_s, nppcrypt::Encoding::base64);
         out << "<tag value=\"" << temp_s << "\" />";
         add_linebreak = true;
     }
@@ -391,14 +391,14 @@ void CryptHeaderWriter::create(const crypt::Options::Crypt& options, const crypt
     out << std::scientific;
 
     buffer.assign(out.str());
-    body.start = (const crypt::byte*)&buffer[body_start];
+    body.start = (const nppcrypt::byte*)&buffer[body_start];
     body.length = body_end - body_start;
 
     if (hmac.enable && hmac_offset > 0) {
         // create hmac hash and insert it into header
-        std::basic_string<crypt::byte> buf;
-        hmac.hash.encoding = crypt::Encoding::base64;
-        crypt::hash(hmac.hash, buf, { { body.start, body.length }, { data, data_length } });
+        std::basic_string<nppcrypt::byte> buf;
+        hmac.hash.encoding = nppcrypt::Encoding::base64;
+        nppcrypt::hash(hmac.hash, buf, { { body.start, body.length }, { data, data_length } });
         std::string tstring(buf.begin(), buf.end());
         buffer.replace(hmac_offset, tstring.size(), tstring);
     }

--- a/src/cryptheader.h
+++ b/src/cryptheader.h
@@ -28,7 +28,7 @@ public:
 
         bool                    enable;
         int                     keypreset_id;
-        crypt::Options::Hash    hash;
+        nppcrypt::Options::Hash    hash;
     };
 
         CryptHeader(HMAC& h) : version(NPPC_VERSION), hmac(h) {};
@@ -39,7 +39,7 @@ protected:
     struct DataPointer {
         DataPointer() : start(NULL), length(0) {};
 
-        const crypt::byte* start;
+        const nppcrypt::byte* start;
         size_t             length;
     };
 
@@ -52,13 +52,13 @@ class CryptHeaderReader : public CryptHeader
 {
 public:
                         CryptHeaderReader(HMAC& hmac) : CryptHeader(hmac) {};
-    bool                parse(crypt::Options::Crypt& options, crypt::InitData& initdata, const crypt::byte* in, size_t in_len);
-    const crypt::byte*  getEncrypted() { return encrypted.start; };
+    bool                parse(nppcrypt::Options::Crypt& options, nppcrypt::InitData& initdata, const nppcrypt::byte* in, size_t in_len);
+    const nppcrypt::byte*  getEncrypted() { return encrypted.start; };
     size_t              getEncryptedLength() { return encrypted.length; };
     bool                checkHMAC();
 
 private:
-    crypt::UserData     hmac_digest;
+    nppcrypt::UserData     hmac_digest;
     DataPointer          encrypted;
 };
 
@@ -66,7 +66,7 @@ class CryptHeaderWriter : public CryptHeader
 {
 public:
                 CryptHeaderWriter(HMAC& hmac) : CryptHeader(hmac) {};
-    void        create(const crypt::Options::Crypt& options, const crypt::InitData& initdata, const crypt::byte* data, size_t data_length);
+    void        create(const nppcrypt::Options::Crypt& options, const nppcrypt::InitData& initdata, const nppcrypt::byte* data, size_t data_length);
     const char* c_str() { return buffer.c_str(); };
     size_t      size() { return buffer.size(); };
 

--- a/src/dlg_auth.cpp
+++ b/src/dlg_auth.cpp
@@ -54,10 +54,10 @@ INT_PTR CALLBACK DlgAuth::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam
         {
         case IDC_OK:
         {
-            crypt::secure_string temp;
+            nppcrypt::secure_string temp;
             getText(IDC_AUTH_KEY, temp);
             if (temp.size()) {
-                crypt::Encoding enc = (crypt::Encoding)::SendDlgItemMessage(_hSelf, IDC_AUTH_KEY_ENC, CB_GETCURSEL, 0, 0);
+                nppcrypt::Encoding enc = (nppcrypt::Encoding)::SendDlgItemMessage(_hSelf, IDC_AUTH_KEY_ENC, CB_GETCURSEL, 0, 0);
                 input.set(temp.c_str(), temp.size(), enc);
             } else {
                 input.clear();
@@ -90,7 +90,7 @@ INT_PTR CALLBACK DlgAuth::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam
     return FALSE;
 }
 
-crypt::UserData& DlgAuth::getInput()
+nppcrypt::UserData& DlgAuth::getInput()
 {
     return input;
 }

--- a/src/dlg_auth.h
+++ b/src/dlg_auth.h
@@ -27,12 +27,12 @@ class DlgAuth: public ModalDialog
 public:    
                         DlgAuth() : ModalDialog() {};
     bool                doDialog(const TCHAR* filename=NULL);
-    crypt::UserData&    getInput();
+    nppcrypt::UserData&    getInput();
 
 private:
     INT_PTR CALLBACK    run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
-    crypt::UserData     input;
+    nppcrypt::UserData     input;
     std::wstring        caption;
 };
 

--- a/src/dlg_convert.cpp
+++ b/src/dlg_convert.cpp
@@ -26,7 +26,7 @@ GNU General Public License for more details.
 #include "preferences.h"
 #include "messagebox.h"
 
-DlgConvert::DlgConvert(crypt::Options::Convert& opt) : ModalDialog(), options(opt)
+DlgConvert::DlgConvert(nppcrypt::Options::Convert& opt) : ModalDialog(), options(opt)
 {
 }
 
@@ -36,7 +36,7 @@ INT_PTR CALLBACK DlgConvert::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPa
     {
     case WM_INITDIALOG:
     {
-        using namespace crypt;
+        using namespace nppcrypt;
 
         ::SendDlgItemMessage(_hSelf, IDC_CONVERT_FROM_ASCII, BM_SETCHECK, (options.from == Encoding::ascii), 0);
         ::SendDlgItemMessage(_hSelf, IDC_CONVERT_FROM_BASE16, BM_SETCHECK, (options.from == Encoding::base16), 0);
@@ -53,8 +53,8 @@ INT_PTR CALLBACK DlgConvert::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPa
         ::SendDlgItemMessage(_hSelf, IDC_CONVERT_LINELENGTH_SPIN, UDM_SETRANGE32, 1, NPPC_MAX_LINE_LENGTH);
         ::SendDlgItemMessage(_hSelf, IDC_CONVERT_LINELENGTH_SPIN, UDM_SETBUDDY, (WPARAM)GetDlgItem(_hSelf, IDC_CONVERT_LINELENGTH), 0);
         ::SendDlgItemMessage(_hSelf, IDC_CONVERT_LINELENGTH_SPIN, UDM_SETPOS32, 0, options.linelength);
-        ::SendDlgItemMessage(_hSelf, IDC_CONVERT_LB_WINDOWS, BM_SETCHECK, (options.eol == crypt::EOL::windows), 0);
-        ::SendDlgItemMessage(_hSelf, IDC_CONVERT_LB_UNIX, BM_SETCHECK, !(options.eol == crypt::EOL::windows), 0);
+        ::SendDlgItemMessage(_hSelf, IDC_CONVERT_LB_WINDOWS, BM_SETCHECK, (options.eol == nppcrypt::EOL::windows), 0);
+        ::SendDlgItemMessage(_hSelf, IDC_CONVERT_LB_UNIX, BM_SETCHECK, !(options.eol == nppcrypt::EOL::windows), 0);
 
         enableOptions((options.to != Encoding::ascii));
         goToCenter();
@@ -83,7 +83,7 @@ INT_PTR CALLBACK DlgConvert::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPa
                         return TRUE;
                     }
 
-                    crypt::convert(pdata, data_length, buffer, options, preferences.getBase32Alphabet(), preferences.getBase64Alphabet());
+                    nppcrypt::convert(pdata, data_length, buffer, options, preferences.getBase32Alphabet(), preferences.getBase64Alphabet());
                     if (LOWORD(wParam) == IDC_OK) {
                         help::scintilla::replaceSelection(buffer);
                     } else {
@@ -104,45 +104,45 @@ INT_PTR CALLBACK DlgConvert::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPa
             }
             case IDC_CONVERT_FROM_ASCII:
             {
-                OnSourceChanged(crypt::Encoding::ascii);
+                OnSourceChanged(nppcrypt::Encoding::ascii);
                 break;
             }
             case IDC_CONVERT_FROM_BASE16:
             {
-                OnSourceChanged(crypt::Encoding::base16);
+                OnSourceChanged(nppcrypt::Encoding::base16);
                 break;
             }
             case IDC_CONVERT_FROM_BASE32:
             {
-                OnSourceChanged(crypt::Encoding::base32);
+                OnSourceChanged(nppcrypt::Encoding::base32);
                 break;
             }
             case IDC_CONVERT_FROM_BASE64:
             {
-                OnSourceChanged(crypt::Encoding::base64);
+                OnSourceChanged(nppcrypt::Encoding::base64);
                 break;
             }
             case IDC_CONVERT_TO_ASCII:
             {
-                OnTargetChanged(crypt::Encoding::ascii);
+                OnTargetChanged(nppcrypt::Encoding::ascii);
                 enableOptions(false);
                 break;
             }
             case IDC_CONVERT_TO_BASE16:
             {
-                OnTargetChanged(crypt::Encoding::base16);
+                OnTargetChanged(nppcrypt::Encoding::base16);
                 enableOptions(true);
                 break;
             }
             case IDC_CONVERT_TO_BASE32:
             {
-                OnTargetChanged(crypt::Encoding::base32);
+                OnTargetChanged(nppcrypt::Encoding::base32);
                 enableOptions(true);
                 break;
             }
             case IDC_CONVERT_TO_BASE64:
             {
-                OnTargetChanged(crypt::Encoding::base64);
+                OnTargetChanged(nppcrypt::Encoding::base64);
                 enableOptions(true);
                 break;
             }
@@ -191,27 +191,27 @@ INT_PTR CALLBACK DlgConvert::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPa
 void DlgConvert::updateOptions()
 {
     if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_FROM_ASCII, BM_GETCHECK, 0, 0))
-        options.from = crypt::Encoding::ascii;
+        options.from = nppcrypt::Encoding::ascii;
     else if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_FROM_BASE16, BM_GETCHECK, 0, 0))
-        options.from = crypt::Encoding::base16;
+        options.from = nppcrypt::Encoding::base16;
     else if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_FROM_BASE32, BM_GETCHECK, 0, 0))
-        options.from = crypt::Encoding::base32;
+        options.from = nppcrypt::Encoding::base32;
     else if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_FROM_BASE64, BM_GETCHECK, 0, 0))
-        options.from = crypt::Encoding::base64;
+        options.from = nppcrypt::Encoding::base64;
 
     if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_TO_ASCII, BM_GETCHECK, 0, 0))
-        options.to = crypt::Encoding::ascii;
+        options.to = nppcrypt::Encoding::ascii;
     else if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_TO_BASE16, BM_GETCHECK, 0, 0))
-        options.to = crypt::Encoding::base16;
+        options.to = nppcrypt::Encoding::base16;
     else if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_TO_BASE32, BM_GETCHECK, 0, 0))
-        options.to = crypt::Encoding::base32;
+        options.to = nppcrypt::Encoding::base32;
     else if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_TO_BASE64, BM_GETCHECK, 0, 0))
-        options.to = crypt::Encoding::base64;
+        options.to = nppcrypt::Encoding::base64;
 
-    if (options.to != crypt::Encoding::ascii) {
+    if (options.to != nppcrypt::Encoding::ascii) {
         options.uppercase = !!::SendDlgItemMessage(_hSelf, IDC_CONVERT_UPPERCASE, BM_GETCHECK, 0, 0);
         options.linebreaks = !!::SendDlgItemMessage(_hSelf, IDC_CONVERT_LINEBREAKS, BM_GETCHECK, 0, 0);
-        options.eol = !!::SendDlgItemMessage(_hSelf, IDC_CONVERT_LB_WINDOWS, BM_GETCHECK, 0, 0) ? crypt::EOL::windows : crypt::EOL::unix;
+        options.eol = !!::SendDlgItemMessage(_hSelf, IDC_CONVERT_LB_WINDOWS, BM_GETCHECK, 0, 0) ? nppcrypt::EOL::windows : nppcrypt::EOL::unix;
         options.linelength = (int)::SendDlgItemMessage(_hSelf, IDC_CONVERT_LINELENGTH_SPIN, UDM_GETPOS32, 0, 0);
     }
 }
@@ -239,11 +239,11 @@ void DlgConvert::enableOptions(bool v) const
     }
 }
 
-void DlgConvert::OnSourceChanged(crypt::Encoding enc) const
+void DlgConvert::OnSourceChanged(nppcrypt::Encoding enc) const
 {
     switch (enc)
     {
-    case crypt::Encoding::ascii:
+    case nppcrypt::Encoding::ascii:
     {
         if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_TO_ASCII, BM_GETCHECK, 0, 0)) {
             ::SendDlgItemMessage(_hSelf, IDC_CONVERT_TO_BASE16, BM_SETCHECK, true, 0);
@@ -252,7 +252,7 @@ void DlgConvert::OnSourceChanged(crypt::Encoding enc) const
         }
         break;
     }
-    case crypt::Encoding::base16:
+    case nppcrypt::Encoding::base16:
     {
         if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_TO_BASE16, BM_GETCHECK, 0, 0)) {
             ::SendDlgItemMessage(_hSelf, IDC_CONVERT_TO_BASE32, BM_SETCHECK, true, 0);
@@ -260,7 +260,7 @@ void DlgConvert::OnSourceChanged(crypt::Encoding enc) const
         }
         break;
     }
-    case crypt::Encoding::base32:
+    case nppcrypt::Encoding::base32:
     {
         if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_TO_BASE32, BM_GETCHECK, 0, 0)) {
             ::SendDlgItemMessage(_hSelf, IDC_CONVERT_TO_BASE64, BM_SETCHECK, true, 0);
@@ -269,7 +269,7 @@ void DlgConvert::OnSourceChanged(crypt::Encoding enc) const
         }
         break;
     }
-    case crypt::Encoding::base64:
+    case nppcrypt::Encoding::base64:
     {
         if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_TO_BASE64, BM_GETCHECK, 0, 0)) {
             ::SendDlgItemMessage(_hSelf, IDC_CONVERT_TO_BASE32, BM_SETCHECK, true, 0);
@@ -280,11 +280,11 @@ void DlgConvert::OnSourceChanged(crypt::Encoding enc) const
     }
 }
 
-void DlgConvert::OnTargetChanged(crypt::Encoding enc) const
+void DlgConvert::OnTargetChanged(nppcrypt::Encoding enc) const
 {
     switch (enc)
     {
-    case crypt::Encoding::ascii:
+    case nppcrypt::Encoding::ascii:
     {
         if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_FROM_ASCII, BM_GETCHECK, 0, 0)) {
             ::SendDlgItemMessage(_hSelf, IDC_CONVERT_FROM_BASE16, BM_SETCHECK, true, 0);
@@ -293,7 +293,7 @@ void DlgConvert::OnTargetChanged(crypt::Encoding enc) const
         }
         break;
     }
-    case crypt::Encoding::base16:
+    case nppcrypt::Encoding::base16:
     {
         if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_FROM_BASE16, BM_GETCHECK, 0, 0)) {
             ::SendDlgItemMessage(_hSelf, IDC_CONVERT_FROM_BASE32, BM_SETCHECK, true, 0);
@@ -301,7 +301,7 @@ void DlgConvert::OnTargetChanged(crypt::Encoding enc) const
         }
         break;
     }
-    case crypt::Encoding::base32:
+    case nppcrypt::Encoding::base32:
     {
         if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_FROM_BASE32, BM_GETCHECK, 0, 0)) {
             ::SendDlgItemMessage(_hSelf, IDC_CONVERT_FROM_BASE64, BM_SETCHECK, true, 0);
@@ -310,7 +310,7 @@ void DlgConvert::OnTargetChanged(crypt::Encoding enc) const
         }
         break;
     }
-    case crypt::Encoding::base64:
+    case nppcrypt::Encoding::base64:
     {
         if (!!::SendDlgItemMessage(_hSelf, IDC_CONVERT_FROM_BASE64, BM_GETCHECK, 0, 0)) {
             ::SendDlgItemMessage(_hSelf, IDC_CONVERT_FROM_BASE32, BM_SETCHECK, true, 0);

--- a/src/dlg_convert.h
+++ b/src/dlg_convert.h
@@ -24,16 +24,16 @@ GNU General Public License for more details.
 class DlgConvert : public ModalDialog
 {
 public:
-                        DlgConvert(crypt::Options::Convert& opt);
+                        DlgConvert(nppcrypt::Options::Convert& opt);
 
 private:
     INT_PTR CALLBACK    run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
     void                updateOptions();
     void                enableOptions(bool v) const;
-    void                OnSourceChanged(crypt::Encoding enc) const;
-    void                OnTargetChanged(crypt::Encoding enc) const;
+    void                OnSourceChanged(nppcrypt::Encoding enc) const;
+    void                OnTargetChanged(nppcrypt::Encoding enc) const;
 
-    crypt::Options::Convert&    options;
+    nppcrypt::Options::Convert&    options;
 };
 
 #endif

--- a/src/dlg_crypt.cpp
+++ b/src/dlg_crypt.cpp
@@ -54,7 +54,7 @@ void DlgCrypt::destroy()
     ModalDialog::destroy();
 };
 
-bool DlgCrypt::encryptDialog(CryptInfo* crypt, crypt::UserData* iv, const std::wstring* filename)
+bool DlgCrypt::encryptDialog(CryptInfo* crypt, nppcrypt::UserData* iv, const std::wstring* filename)
 {
     if (!setup(crypt, iv, filename)) {
         return false;
@@ -64,7 +64,7 @@ bool DlgCrypt::encryptDialog(CryptInfo* crypt, crypt::UserData* iv, const std::w
     return ModalDialog::doDialog();
 }
 
-bool DlgCrypt::decryptDialog(CryptInfo* crypt, crypt::UserData* iv, const std::wstring* filename, bool disable_easymode)
+bool DlgCrypt::decryptDialog(CryptInfo* crypt, nppcrypt::UserData* iv, const std::wstring* filename, bool disable_easymode)
 {
     if (!setup(crypt, iv, filename)) {
         return false;
@@ -74,7 +74,7 @@ bool DlgCrypt::decryptDialog(CryptInfo* crypt, crypt::UserData* iv, const std::w
     return ModalDialog::doDialog();
 }
 
-bool DlgCrypt::setup(CryptInfo* crypt, crypt::UserData* iv, const std::wstring* filename)
+bool DlgCrypt::setup(CryptInfo* crypt, nppcrypt::UserData* iv, const std::wstring* filename)
 {
     if (!crypt || !iv) {
         return false;
@@ -163,22 +163,22 @@ INT_PTR CALLBACK DlgCrypt::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPara
             }
             case IDC_CRYPT_ENC_ASCII:
             {
-                updateEncodingControls(crypt::Encoding::ascii);
+                updateEncodingControls(nppcrypt::Encoding::ascii);
                 break;
             }
             case IDC_CRYPT_ENC_BASE16:
             {
-                updateEncodingControls(crypt::Encoding::base16);
+                updateEncodingControls(nppcrypt::Encoding::base16);
                 break;
             }
             case IDC_CRYPT_ENC_BASE32:
             {
-                updateEncodingControls(crypt::Encoding::base32);
+                updateEncodingControls(nppcrypt::Encoding::base32);
                 break;
             }
             case IDC_CRYPT_ENC_BASE64:
             {
-                updateEncodingControls(crypt::Encoding::base64);
+                updateEncodingControls(nppcrypt::Encoding::base64);
                 break;
             }
             case IDC_CRYPT_ENC_LINEBREAK:
@@ -194,18 +194,18 @@ INT_PTR CALLBACK DlgCrypt::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPara
             case IDC_CRYPT_KEY_PBKDF2: case IDC_CRYPT_KEY_BCRYPT: case IDC_CRYPT_KEY_SCRYPT:
             {
                 if (!!::SendDlgItemMessage(tab.key, IDC_CRYPT_KEY_PBKDF2, BM_GETCHECK, 0, 0)) {
-                    current.key_derivation = crypt::KeyDerivation::pbkdf2;
+                    current.key_derivation = nppcrypt::KeyDerivation::pbkdf2;
                 } else if (!!::SendDlgItemMessage(tab.key, IDC_CRYPT_KEY_BCRYPT, BM_GETCHECK, 0, 0)) {
-                    current.key_derivation = crypt::KeyDerivation::bcrypt;
+                    current.key_derivation = nppcrypt::KeyDerivation::bcrypt;
                 } else {
-                    current.key_derivation = crypt::KeyDerivation::scrypt;
+                    current.key_derivation = nppcrypt::KeyDerivation::scrypt;
                 }
                 updateKeyDerivationControls();
                 break;
             }
             case IDC_CRYPT_SALT:
             {
-                if (current.key_derivation != crypt::KeyDerivation::bcrypt) {
+                if (current.key_derivation != nppcrypt::KeyDerivation::bcrypt) {
                     bool c = ::SendDlgItemMessage(tab.key, IDC_CRYPT_SALT, BM_GETCHECK, 0, 0) ? true : false;
                     ::EnableWindow(::GetDlgItem(tab.key, IDC_CRYPT_SALT_BYTES), c);
                     ::EnableWindow(::GetDlgItem(tab.key, IDC_CRYPT_SALT_SPIN), c);
@@ -284,7 +284,7 @@ INT_PTR CALLBACK DlgCrypt::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPara
             {
                 int category = (int)::SendDlgItemMessage(tab.basic, IDC_CRYPT_CIPHER_TYPE, CB_GETCURSEL, 0, 0);
                 ::SendDlgItemMessage(tab.basic, IDC_CRYPT_CIPHER, CB_RESETCONTENT, 0, 0);
-                for (crypt::help::CipherNames it(category); *it; ++it) {
+                for (nppcrypt::help::CipherNames it(category); *it; ++it) {
                     ::SendDlgItemMessage(tab.basic, IDC_CRYPT_CIPHER, CB_ADDSTRING, 0, (LPARAM)help::windows::ToWCHAR(*it).c_str());
                 }
                 ::SendDlgItemMessage(tab.basic, IDC_CRYPT_CIPHER, CB_SETCURSEL, 0, 0);
@@ -298,7 +298,7 @@ INT_PTR CALLBACK DlgCrypt::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPara
             }
             case IDC_CRYPT_MODE:
             {
-                current.mode = crypt::help::getModeByIndex(current.cipher, (int)::SendDlgItemMessage(tab.basic, IDC_CRYPT_MODE, CB_GETCURSEL, 0, 0));
+                current.mode = nppcrypt::help::getModeByIndex(current.cipher, (int)::SendDlgItemMessage(tab.basic, IDC_CRYPT_MODE, CB_GETCURSEL, 0, 0));
                 updateCipherInfo();
                 PostMessage(tab.basic, WM_NEXTDLGCTL, (WPARAM)::GetDlgItem(tab.basic, IDC_CRYPT_PASSWORD_ADVANCED), TRUE);
                 break;
@@ -310,21 +310,21 @@ INT_PTR CALLBACK DlgCrypt::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPara
             }
             case IDC_CRYPT_PASSWORD_ENC:
             {
-                crypt::secure_string temp;
+                nppcrypt::secure_string temp;
                 checkPassword(temp, false);
                 ::SetFocus(::GetDlgItem(tab.basic, IDC_CRYPT_PASSWORD_ADVANCED));
                 break;
             }
             case IDC_CRYPT_PBKDF2_HASH:
             {
-                crypt::Hash cur_sel = crypt::help::getHashByIndex(::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH, CB_GETCURSEL, 0, 0), crypt::HMAC_SUPPORT);
+                nppcrypt::Hash cur_sel = nppcrypt::help::getHashByIndex(::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH, CB_GETCURSEL, 0, 0), nppcrypt::HMAC_SUPPORT);
                 updateHashDigestControl(cur_sel, tab.key, IDC_CRYPT_PBKDF2_HASH_LENGTH);
                 ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH_LENGTH, CB_SETCURSEL, 0, 0);
                 break;
             }
             case IDC_CRYPT_IV_ENC:
             {
-                crypt::UserData ivdata;
+                nppcrypt::UserData ivdata;
                 invalid.iv = !checkCustomIV(ivdata, true);
                 InvalidateRect(::GetDlgItem(tab.iv, IDC_CRYPT_IV_INPUT), NULL, NULL);
                 ::SetFocus(::GetDlgItem(tab.iv, IDC_CRYPT_IV_INPUT));
@@ -332,7 +332,7 @@ INT_PTR CALLBACK DlgCrypt::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPara
             }
             case IDC_CRYPT_AUTH_HASH:
             {
-                crypt::Hash cur_sel = crypt::help::getHashByIndex(::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_HASH, CB_GETCURSEL, 0, 0), crypt::HMAC_SUPPORT);
+                nppcrypt::Hash cur_sel = nppcrypt::help::getHashByIndex(::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_HASH, CB_GETCURSEL, 0, 0), nppcrypt::HMAC_SUPPORT);
                 updateHashDigestControl(cur_sel, tab.auth, IDC_CRYPT_AUTH_HASH_LENGTH);
                 ::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_HASH_LENGTH, CB_SETCURSEL, 0, 0);
                 if (!!::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_KEY_CUSTOM, BM_GETCHECK, 0, 0)) {
@@ -374,14 +374,14 @@ INT_PTR CALLBACK DlgCrypt::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPara
         {
             checkSpinControlValue(LOWORD(wParam));
             if (LOWORD(wParam) == IDC_CRYPT_IV_INPUT) {
-                crypt::UserData ivdata;
+                nppcrypt::UserData ivdata;
                 invalid.iv = !checkCustomIV(ivdata, false);
                 InvalidateRect(::GetDlgItem(tab.iv, IDC_CRYPT_IV_INPUT), NULL, NULL);
             } else if (LOWORD(wParam) == IDC_CRYPT_AUTH_PW_VALUE) {
                 invalid.hmac_key = !checkHMACKey(crypt->hmac.hash.key, false);
                 InvalidateRect(::GetDlgItem(tab.auth, IDC_CRYPT_AUTH_PW_VALUE), NULL, NULL);
             } else if (LOWORD(wParam) == IDC_CRYPT_PASSWORD_ADVANCED || LOWORD(wParam) == IDC_CRYPT_PASSWORD_EASY) {
-                crypt::secure_string temp;
+                nppcrypt::secure_string temp;
                 checkPassword(temp, false);
             }
             break;
@@ -465,17 +465,17 @@ void DlgCrypt::setupDialog()
     current.cipher = crypt->options.cipher;
     current.key_length = crypt->options.key.length;
     current.mode = crypt->options.mode;
-    int category = crypt::help::getCipherCategory(current.cipher);
+    int category = nppcrypt::help::getCipherCategory(current.cipher);
 
-    for (crypt::help::CipherCategories it; *it; ++it) {
+    for (nppcrypt::help::CipherCategories it; *it; ++it) {
         ::SendDlgItemMessage(tab.basic, IDC_CRYPT_CIPHER_TYPE, CB_ADDSTRING, 0, (LPARAM)help::windows::ToWCHAR(*it).c_str());
     }
     ::SendDlgItemMessage(tab.basic, IDC_CRYPT_CIPHER_TYPE, CB_SETCURSEL, category, 0);
     ::SendDlgItemMessage(tab.basic, IDC_CRYPT_CIPHER, CB_RESETCONTENT, 0, 0);
-    for (crypt::help::CipherNames it(category); *it; ++it) {
+    for (nppcrypt::help::CipherNames it(category); *it; ++it) {
         ::SendDlgItemMessage(tab.basic, IDC_CRYPT_CIPHER, CB_ADDSTRING, 0, (LPARAM)help::windows::ToWCHAR(*it).c_str());
     }
-    ::SendDlgItemMessage(tab.basic, IDC_CRYPT_CIPHER, CB_SETCURSEL, crypt::help::getCipherIndex(current.cipher), 0);
+    ::SendDlgItemMessage(tab.basic, IDC_CRYPT_CIPHER, CB_SETCURSEL, nppcrypt::help::getCipherIndex(current.cipher), 0);
 
     // ------- Cipher Modes ------------------------------------------------------
 
@@ -497,19 +497,19 @@ void DlgCrypt::setupDialog()
     // ------- Encoding
     // no binary output if buffer is 16 bit
     if (operation == Operation::Encryption && !help::buffer::isCurrent8Bit()) {
-        if (crypt->options.encoding.enc == crypt::Encoding::ascii) {
-            crypt->options.encoding.enc = crypt::Encoding::base16;
+        if (crypt->options.encoding.enc == nppcrypt::Encoding::ascii) {
+            crypt->options.encoding.enc = nppcrypt::Encoding::base16;
         }
         ::EnableWindow(::GetDlgItem(tab.encoding, IDC_CRYPT_ENC_ASCII), false);
     }
-    ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_ASCII, BM_SETCHECK, (crypt->options.encoding.enc == crypt::Encoding::ascii), 0);
-    ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_BASE16, BM_SETCHECK, (crypt->options.encoding.enc == crypt::Encoding::base16), 0);
-    ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_BASE32, BM_SETCHECK, (crypt->options.encoding.enc == crypt::Encoding::base32), 0);
-    ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_BASE64, BM_SETCHECK, (crypt->options.encoding.enc == crypt::Encoding::base64), 0);
+    ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_ASCII, BM_SETCHECK, (crypt->options.encoding.enc == nppcrypt::Encoding::ascii), 0);
+    ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_BASE16, BM_SETCHECK, (crypt->options.encoding.enc == nppcrypt::Encoding::base16), 0);
+    ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_BASE32, BM_SETCHECK, (crypt->options.encoding.enc == nppcrypt::Encoding::base32), 0);
+    ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_BASE64, BM_SETCHECK, (crypt->options.encoding.enc == nppcrypt::Encoding::base64), 0);
 
     ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_LINEBREAK, BM_SETCHECK, crypt->options.encoding.linebreaks, 0);
-    ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_LB_WIN, BM_SETCHECK, (crypt->options.encoding.eol == crypt::EOL::windows), 0);
-    ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_LB_UNIX, BM_SETCHECK, (crypt->options.encoding.eol != crypt::EOL::windows), 0);
+    ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_LB_WIN, BM_SETCHECK, (crypt->options.encoding.eol == nppcrypt::EOL::windows), 0);
+    ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_LB_UNIX, BM_SETCHECK, (crypt->options.encoding.eol != nppcrypt::EOL::windows), 0);
     ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_UPPERCASE, BM_SETCHECK, crypt->options.encoding.uppercase, 0);
 
     ::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_LINELEN_SPIN, UDM_SETRANGE32, 1, NPPC_MAX_LINE_LENGTH);
@@ -530,55 +530,55 @@ void DlgCrypt::setupDialog()
     }
 
     // ------- Key-Derivation
-    ::SendDlgItemMessage(tab.key, IDC_CRYPT_SALT_SPIN, UDM_SETRANGE32, 1, crypt::Constants::salt_max);
+    ::SendDlgItemMessage(tab.key, IDC_CRYPT_SALT_SPIN, UDM_SETRANGE32, 1, nppcrypt::Constants::salt_max);
     ::SendDlgItemMessage(tab.key, IDC_CRYPT_SALT_SPIN, UDM_SETBUDDY, (WPARAM)GetDlgItem(tab.key, IDC_CRYPT_SALT_BYTES), 0);
     ::SendDlgItemMessage(tab.key, IDC_CRYPT_SALT_SPIN, UDM_SETPOS32, 0, crypt->options.key.salt_bytes);
     ::SendDlgItemMessage(tab.key, IDC_CRYPT_SALT, BM_SETCHECK, (crypt->options.key.salt_bytes > 0), 0);
 
-    for (crypt::help::Hashnames it(crypt::HMAC_SUPPORT); *it; ++it) {
+    for (nppcrypt::help::Hashnames it(nppcrypt::HMAC_SUPPORT); *it; ++it) {
         ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH, CB_ADDSTRING, 0, (LPARAM)help::windows::ToWCHAR(*it).c_str());
     }
-    ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_ITER_SPIN, UDM_SETRANGE32, crypt::Constants::pbkdf2_iter_min, crypt::Constants::pbkdf2_iter_max);
+    ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_ITER_SPIN, UDM_SETRANGE32, nppcrypt::Constants::pbkdf2_iter_min, nppcrypt::Constants::pbkdf2_iter_max);
     ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_ITER_SPIN, UDM_SETBUDDY, (WPARAM)GetDlgItem(tab.key, IDC_CRYPT_PBKDF2_ITER), 0);
-    ::SendDlgItemMessage(tab.key, IDC_CRYPT_BCRYPT_ITER_SPIN, UDM_SETRANGE32, crypt::Constants::bcrypt_iter_min, crypt::Constants::bcrypt_iter_max);
+    ::SendDlgItemMessage(tab.key, IDC_CRYPT_BCRYPT_ITER_SPIN, UDM_SETRANGE32, nppcrypt::Constants::bcrypt_iter_min, nppcrypt::Constants::bcrypt_iter_max);
     ::SendDlgItemMessage(tab.key, IDC_CRYPT_BCRYPT_ITER_SPIN, UDM_SETBUDDY, (WPARAM)GetDlgItem(tab.key, IDC_CRYPT_BCRYPT_ITER), 0);
-    ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_N_SPIN, UDM_SETRANGE32, crypt::Constants::scrypt_N_min, crypt::Constants::scrypt_N_max);
+    ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_N_SPIN, UDM_SETRANGE32, nppcrypt::Constants::scrypt_N_min, nppcrypt::Constants::scrypt_N_max);
     ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_N_SPIN, UDM_SETBUDDY, (WPARAM)GetDlgItem(tab.key, IDC_CRYPT_SCRYPT_N), 0);
-    ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_R_SPIN, UDM_SETRANGE32, crypt::Constants::scrypt_r_min, crypt::Constants::scrypt_r_max);
+    ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_R_SPIN, UDM_SETRANGE32, nppcrypt::Constants::scrypt_r_min, nppcrypt::Constants::scrypt_r_max);
     ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_R_SPIN, UDM_SETBUDDY, (WPARAM)GetDlgItem(tab.key, IDC_CRYPT_SCRYPT_R), 0);
-    ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_P_SPIN, UDM_SETRANGE32, crypt::Constants::scrypt_p_min, crypt::Constants::scrypt_p_max);
+    ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_P_SPIN, UDM_SETRANGE32, nppcrypt::Constants::scrypt_p_min, nppcrypt::Constants::scrypt_p_max);
     ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_P_SPIN, UDM_SETBUDDY, (WPARAM)GetDlgItem(tab.key, IDC_CRYPT_SCRYPT_P), 0);
-    ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH, CB_SETCURSEL, crypt::help::getHashIndex(crypt::Constants::pbkdf2_default_hash, crypt::HMAC_SUPPORT), 0);
-    ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_ITER_SPIN, UDM_SETPOS32, 0, crypt::Constants::pbkdf2_iter_default);
-    ::SendDlgItemMessage(tab.key, IDC_CRYPT_BCRYPT_ITER_SPIN, UDM_SETPOS32, 0, crypt::Constants::bcrypt_iter_default);
-    ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_N_SPIN, UDM_SETPOS32, 0, crypt::Constants::scrypt_N_default);
-    ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_R_SPIN, UDM_SETPOS32, 0, crypt::Constants::scrypt_r_default);
-    ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_P_SPIN, UDM_SETPOS32, 0, crypt::Constants::scrypt_p_default);
+    ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH, CB_SETCURSEL, nppcrypt::help::getHashIndex(nppcrypt::Constants::pbkdf2_default_hash, nppcrypt::HMAC_SUPPORT), 0);
+    ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_ITER_SPIN, UDM_SETPOS32, 0, nppcrypt::Constants::pbkdf2_iter_default);
+    ::SendDlgItemMessage(tab.key, IDC_CRYPT_BCRYPT_ITER_SPIN, UDM_SETPOS32, 0, nppcrypt::Constants::bcrypt_iter_default);
+    ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_N_SPIN, UDM_SETPOS32, 0, nppcrypt::Constants::scrypt_N_default);
+    ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_R_SPIN, UDM_SETPOS32, 0, nppcrypt::Constants::scrypt_r_default);
+    ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_P_SPIN, UDM_SETPOS32, 0, nppcrypt::Constants::scrypt_p_default);
 
     current.key_derivation = crypt->options.key.algorithm;
     switch (crypt->options.key.algorithm) {
-    case crypt::KeyDerivation::pbkdf2:
+    case nppcrypt::KeyDerivation::pbkdf2:
         ::SendDlgItemMessage(tab.key, IDC_CRYPT_KEY_PBKDF2, BM_SETCHECK, true, 0);
-        ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH, CB_SETCURSEL, crypt::help::getHashIndex((crypt::Hash)crypt->options.key.options[0],crypt::HMAC_SUPPORT), 0);
+        ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH, CB_SETCURSEL, nppcrypt::help::getHashIndex((nppcrypt::Hash)crypt->options.key.options[0],nppcrypt::HMAC_SUPPORT), 0);
         ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_ITER_SPIN, UDM_SETPOS32, 0, crypt->options.key.options[2]);
         break;
-    case crypt::KeyDerivation::bcrypt:
+    case nppcrypt::KeyDerivation::bcrypt:
         ::SendDlgItemMessage(tab.key, IDC_CRYPT_KEY_BCRYPT, BM_SETCHECK, true, 0);
         ::SendDlgItemMessage(tab.key, IDC_CRYPT_BCRYPT_ITER_SPIN, UDM_SETPOS32, 0, crypt->options.key.options[0]);
         break;
-    case crypt::KeyDerivation::scrypt:
+    case nppcrypt::KeyDerivation::scrypt:
         ::SendDlgItemMessage(tab.key, IDC_CRYPT_KEY_SCRYPT, BM_SETCHECK, true, 0);
         ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_N_SPIN, UDM_SETPOS32, 0, crypt->options.key.options[0]);
         ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_R_SPIN, UDM_SETPOS32, 0, crypt->options.key.options[1]);
         ::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_P_SPIN, UDM_SETPOS32, 0, crypt->options.key.options[2]);
         break;
     }
-    crypt::Hash cur_sel = crypt::help::getHashByIndex(::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH, CB_GETCURSEL, 0, 0), crypt::HMAC_SUPPORT);
+    nppcrypt::Hash cur_sel = nppcrypt::help::getHashByIndex(::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH, CB_GETCURSEL, 0, 0), nppcrypt::HMAC_SUPPORT);
     updateHashDigestControl(cur_sel, tab.key, IDC_CRYPT_PBKDF2_HASH_LENGTH);
-    if (crypt->options.key.algorithm == crypt::KeyDerivation::pbkdf2) {
-        ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH_LENGTH, CB_SETCURSEL, crypt::help::getHashDigestIndex(cur_sel, crypt->options.key.options[1]), 0);
+    if (crypt->options.key.algorithm == nppcrypt::KeyDerivation::pbkdf2) {
+        ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH_LENGTH, CB_SETCURSEL, nppcrypt::help::getHashDigestIndex(cur_sel, crypt->options.key.options[1]), 0);
     } else {
-        ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH_LENGTH, CB_SETCURSEL, crypt::help::getHashDigestIndex(cur_sel, crypt::Constants::pbkdf2_default_hash_digest), 0);
+        ::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH_LENGTH, CB_SETCURSEL, nppcrypt::help::getHashDigestIndex(cur_sel, nppcrypt::Constants::pbkdf2_default_hash_digest), 0);
     }
 
     help.salt.setup(_hInst, tab.key, ::GetDlgItem(tab.key, IDC_CRYPT_HELP_SALT));
@@ -595,17 +595,17 @@ void DlgCrypt::setupDialog()
     setupInputEncodingSelect(tab.iv, IDC_CRYPT_IV_ENC);
 
     if (operation == Operation::Encryption) {
-        if (filename != NULL && crypt->options.iv == crypt::IV::custom) {
+        if (filename != NULL && crypt->options.iv == nppcrypt::IV::custom) {
             // nppcrypt-file: no encryption with custom IV
             ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_RANDOM, BM_SETCHECK, true, 0);
             ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_KEY, BM_SETCHECK, false, 0);
             ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_ZERO, BM_SETCHECK, false, 0);
             ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_CUSTOM, BM_SETCHECK, false, 0);
         } else {
-            ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_RANDOM, BM_SETCHECK, (crypt->options.iv == crypt::IV::random), 0);
-            ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_KEY, BM_SETCHECK, (crypt->options.iv == crypt::IV::keyderivation), 0);
-            ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_ZERO, BM_SETCHECK, (crypt->options.iv == crypt::IV::zero), 0);
-            ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_CUSTOM, BM_SETCHECK, (crypt->options.iv == crypt::IV::custom), 0);
+            ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_RANDOM, BM_SETCHECK, (crypt->options.iv == nppcrypt::IV::random), 0);
+            ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_KEY, BM_SETCHECK, (crypt->options.iv == nppcrypt::IV::keyderivation), 0);
+            ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_ZERO, BM_SETCHECK, (crypt->options.iv == nppcrypt::IV::zero), 0);
+            ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_CUSTOM, BM_SETCHECK, (crypt->options.iv == nppcrypt::IV::custom), 0);
         }
     } else {
         ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_RANDOM, BM_SETCHECK, false, 0);
@@ -613,21 +613,21 @@ void DlgCrypt::setupDialog()
         ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_ZERO, BM_SETCHECK, false, 0);
         ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_CUSTOM, BM_SETCHECK, true, 0);
         if (ivdata->size() > 0) {
-            crypt::secure_string temp;
-            ivdata->get(temp, crypt::Encoding::base64);
-            ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_ENC, CB_SETCURSEL, (int)crypt::Encoding::base64, 0);
+            nppcrypt::secure_string temp;
+            ivdata->get(temp, nppcrypt::Encoding::base64);
+            ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_ENC, CB_SETCURSEL, (int)nppcrypt::Encoding::base64, 0);
             setText(IDC_CRYPT_IV_INPUT, temp, tab.iv);
         }
     }
 
     // ------- Auth
     ::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_ENABLE, BM_SETCHECK, crypt->hmac.enable, 0);
-    for(crypt::help::Hashnames it(crypt::HMAC_SUPPORT); *it; ++it) {
+    for(nppcrypt::help::Hashnames it(nppcrypt::HMAC_SUPPORT); *it; ++it) {
         ::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_HASH, CB_ADDSTRING, 0, (LPARAM)help::windows::ToWCHAR(*it).c_str());
     }
-    ::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_HASH, CB_SETCURSEL, crypt::help::getHashIndex(crypt->hmac.hash.algorithm, crypt::HMAC_SUPPORT), 0);
+    ::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_HASH, CB_SETCURSEL, nppcrypt::help::getHashIndex(crypt->hmac.hash.algorithm, nppcrypt::HMAC_SUPPORT), 0);
     updateHashDigestControl(crypt->hmac.hash.algorithm, tab.auth, IDC_CRYPT_AUTH_HASH_LENGTH);
-    ::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_HASH_LENGTH, CB_SETCURSEL, crypt::help::getHashDigestIndex(crypt->hmac.hash.algorithm, (unsigned int)crypt->hmac.hash.digest_length), 0);
+    ::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_HASH_LENGTH, CB_SETCURSEL, nppcrypt::help::getHashDigestIndex(crypt->hmac.hash.algorithm, (unsigned int)crypt->hmac.hash.digest_length), 0);
     for (size_t i = 0; i < preferences.getKeyNum(); i++) {
         ::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_KEY_LIST, CB_ADDSTRING, 0, (LPARAM)preferences.getKeyLabel(i));
     }
@@ -678,7 +678,7 @@ void DlgCrypt::setupDialog()
     // -------
     updateCipherControls();
     if (current.iv_length > 0 && !!::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_CUSTOM, BM_GETCHECK, 0, 0)) {
-        crypt::UserData ivdata;
+        nppcrypt::UserData ivdata;
         invalid.iv = !checkCustomIV(ivdata, true);
         if (invalid.iv) {
             InvalidateRect(::GetDlgItem(tab.iv, IDC_CRYPT_IV_INPUT), NULL, NULL);
@@ -698,7 +698,7 @@ void DlgCrypt::changeActiveTab(int id)
 {
     if (id == 3) {
         if (::IsWindowEnabled(::GetDlgItem(tab.iv, IDC_CRYPT_IV_CUSTOM)) && ::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_CUSTOM, BM_GETCHECK, 0, 0)) {
-            crypt::UserData ivdata;
+            nppcrypt::UserData ivdata;
             invalid.iv = !checkCustomIV(ivdata, true);
             if (invalid.iv) {
                 InvalidateRect(::GetDlgItem(tab.iv, IDC_CRYPT_IV_INPUT), NULL, NULL);
@@ -707,7 +707,7 @@ void DlgCrypt::changeActiveTab(int id)
     } else if (operation == Operation::Encryption && id == 4) {
         if (!!::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_ENABLE, BM_GETCHECK, 0, 0) &&
             !!::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_KEY_CUSTOM, BM_GETCHECK, 0, 0)) {
-            crypt::UserData tempkey;
+            nppcrypt::UserData tempkey;
             invalid.hmac_key = !checkHMACKey(tempkey, true);
             if (invalid.hmac_key) {
                 InvalidateRect(::GetDlgItem(tab.auth, IDC_CRYPT_AUTH_PW_VALUE), NULL, NULL);
@@ -816,29 +816,29 @@ bool DlgCrypt::prepareOptionsAdvanced()
         int cipher_index = (int)::SendDlgItemMessage(tab.basic, IDC_CRYPT_CIPHER, CB_GETCURSEL, 0, 0);
         int cipher_cat = (int)::SendDlgItemMessage(tab.basic, IDC_CRYPT_CIPHER_TYPE, CB_GETCURSEL, 0, 0);
         int cipher_keylength = (int)::SendDlgItemMessage(tab.basic, IDC_CRYPT_KEYLENGTH, CB_GETCURSEL, 0, 0);
-        crypt->options.cipher = crypt::help::getCipherByIndex(cipher_cat, cipher_index);
-        crypt->options.key.length = crypt::help::getCipherKeylengthByIndex(crypt->options.cipher, cipher_keylength);
+        crypt->options.cipher = nppcrypt::help::getCipherByIndex(cipher_cat, cipher_index);
+        crypt->options.key.length = nppcrypt::help::getCipherKeylengthByIndex(crypt->options.cipher, cipher_keylength);
         int t_mode = (int)::SendDlgItemMessage(tab.basic, IDC_CRYPT_MODE, CB_GETCURSEL, 0, 0);
-        crypt->options.mode = (t_mode >= 0) ? crypt::help::getModeByIndex(crypt->options.cipher, t_mode) : crypt::Mode::cbc;
+        crypt->options.mode = (t_mode >= 0) ? nppcrypt::help::getModeByIndex(crypt->options.cipher, t_mode) : nppcrypt::Mode::cbc;
 
-        if ((crypt->options.mode == crypt::Mode::gcm || crypt->options.mode == crypt::Mode::ccm || crypt->options.mode == crypt::Mode::eax) &&
-            crypt::help::checkProperty(crypt->options.cipher, crypt::BLOCK)) {
+        if ((crypt->options.mode == nppcrypt::Mode::gcm || crypt->options.mode == nppcrypt::Mode::ccm || crypt->options.mode == nppcrypt::Mode::eax) &&
+            nppcrypt::help::checkProperty(crypt->options.cipher, nppcrypt::BLOCK)) {
             crypt->options.aad = !!::SendDlgItemMessage(tab.basic, IDC_CRYPT_AUTH_IVSALT, BM_GETCHECK, 0, 0);
         }
 
         // ------- encoding
         if (::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_ASCII, BM_GETCHECK, 0, 0)) {
-            crypt->options.encoding.enc = crypt::Encoding::ascii;
+            crypt->options.encoding.enc = nppcrypt::Encoding::ascii;
         } else if (::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_BASE16, BM_GETCHECK, 0, 0)) {
-            crypt->options.encoding.enc = crypt::Encoding::base16;
+            crypt->options.encoding.enc = nppcrypt::Encoding::base16;
         } else if (::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_BASE32, BM_GETCHECK, 0, 0)) {
-            crypt->options.encoding.enc = crypt::Encoding::base32;
+            crypt->options.encoding.enc = nppcrypt::Encoding::base32;
         } else {
-            crypt->options.encoding.enc = crypt::Encoding::base64;
+            crypt->options.encoding.enc = nppcrypt::Encoding::base64;
         }
         crypt->options.encoding.linebreaks = !!::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_LINEBREAK, BM_GETCHECK, 0, 0);
         crypt->options.encoding.uppercase = !!::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_UPPERCASE, BM_GETCHECK, 0, 0);
-        crypt->options.encoding.eol = !!::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_LB_WIN, BM_GETCHECK, 0, 0) ? crypt::EOL::windows : crypt::EOL::unix;
+        crypt->options.encoding.eol = !!::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_LB_WIN, BM_GETCHECK, 0, 0) ? nppcrypt::EOL::windows : nppcrypt::EOL::unix;
         crypt->options.encoding.linelength = (int)::SendDlgItemMessage(tab.encoding, IDC_CRYPT_ENC_LINELEN_SPIN, UDM_GETPOS32, 0, 0);
 
         // ------- salt
@@ -850,18 +850,18 @@ bool DlgCrypt::prepareOptionsAdvanced()
 
         // ------- key derivation
         if (::SendDlgItemMessage(tab.key, IDC_CRYPT_KEY_PBKDF2, BM_GETCHECK, 0, 0)) {
-            crypt->options.key.algorithm = crypt::KeyDerivation::pbkdf2;
-            crypt::Hash h = crypt::help::getHashByIndex(::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH, CB_GETCURSEL, 0, 0), crypt::HMAC_SUPPORT);
+            crypt->options.key.algorithm = nppcrypt::KeyDerivation::pbkdf2;
+            nppcrypt::Hash h = nppcrypt::help::getHashByIndex(::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH, CB_GETCURSEL, 0, 0), nppcrypt::HMAC_SUPPORT);
             crypt->options.key.options[0] = (int)h;
-            crypt->options.key.options[1] = (int)crypt::help::getHashDigestByIndex(h, (unsigned int)::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH_LENGTH, CB_GETCURSEL, 0, 0));
+            crypt->options.key.options[1] = (int)nppcrypt::help::getHashDigestByIndex(h, (unsigned int)::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_HASH_LENGTH, CB_GETCURSEL, 0, 0));
             crypt->options.key.options[2] = (int)::SendDlgItemMessage(tab.key, IDC_CRYPT_PBKDF2_ITER_SPIN, UDM_GETPOS32, 0, 0);
         } else if (::SendDlgItemMessage(tab.key, IDC_CRYPT_KEY_BCRYPT, BM_GETCHECK, 0, 0)) {
-            crypt->options.key.algorithm = crypt::KeyDerivation::bcrypt;
+            crypt->options.key.algorithm = nppcrypt::KeyDerivation::bcrypt;
             crypt->options.key.options[0] = (int)::SendDlgItemMessage(tab.key, IDC_CRYPT_BCRYPT_ITER_SPIN, UDM_GETPOS32, 0, 0);
             crypt->options.key.options[1] = 0;
             crypt->options.key.options[2] = 0;
         } else {
-            crypt->options.key.algorithm = crypt::KeyDerivation::scrypt;
+            crypt->options.key.algorithm = nppcrypt::KeyDerivation::scrypt;
             crypt->options.key.options[0] = (int)::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_N_SPIN, UDM_GETPOS32, 0, 0);
             crypt->options.key.options[1] = (int)::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_R_SPIN, UDM_GETPOS32, 0, 0);
             crypt->options.key.options[2] = (int)::SendDlgItemMessage(tab.key, IDC_CRYPT_SCRYPT_P_SPIN, UDM_GETPOS32, 0, 0);
@@ -870,18 +870,18 @@ bool DlgCrypt::prepareOptionsAdvanced()
         // ------- iv
         if (operation == Operation::Encryption) {
             if (::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_RANDOM, BM_GETCHECK, 0, 0)) {
-                crypt->options.iv = crypt::IV::random;
+                crypt->options.iv = nppcrypt::IV::random;
             } else if (::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_KEY, BM_GETCHECK, 0, 0)) {
-                crypt->options.iv = crypt::IV::keyderivation;
+                crypt->options.iv = nppcrypt::IV::keyderivation;
             } else if (::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_ZERO, BM_GETCHECK, 0, 0)) {
-                crypt->options.iv = crypt::IV::zero;
+                crypt->options.iv = nppcrypt::IV::zero;
             } else {
-                crypt->options.iv = crypt::IV::custom;
+                crypt->options.iv = nppcrypt::IV::custom;
             }
         }
 
-        if (current.iv_length > 0 && (operation == Operation::Decryption || crypt->options.iv == crypt::IV::custom)) {
-            crypt::UserData data;
+        if (current.iv_length > 0 && (operation == Operation::Decryption || crypt->options.iv == nppcrypt::IV::custom)) {
+            nppcrypt::UserData data;
             if (!checkCustomIV(data, true)) {
                 throwInvalid(invalid_iv);
             } else {
@@ -893,9 +893,9 @@ bool DlgCrypt::prepareOptionsAdvanced()
         if (operation == Operation::Encryption) {
             crypt->hmac.enable = (::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_ENABLE, BM_GETCHECK, 0, 0) ? true : false);
             if (crypt->hmac.enable) {
-                crypt->hmac.hash.algorithm = crypt::help::getHashByIndex(::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_HASH, CB_GETCURSEL, 0, 0), crypt::HMAC_SUPPORT);
-                crypt->hmac.hash.digest_length = crypt::help::getHashDigestByIndex(crypt->hmac.hash.algorithm, (unsigned int)::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_HASH_LENGTH, CB_GETCURSEL, 0, 0));
-                crypt->hmac.hash.encoding = crypt::Encoding::base64;
+                crypt->hmac.hash.algorithm = nppcrypt::help::getHashByIndex(::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_HASH, CB_GETCURSEL, 0, 0), nppcrypt::HMAC_SUPPORT);
+                crypt->hmac.hash.digest_length = nppcrypt::help::getHashDigestByIndex(crypt->hmac.hash.algorithm, (unsigned int)::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_HASH_LENGTH, CB_GETCURSEL, 0, 0));
+                crypt->hmac.hash.encoding = nppcrypt::Encoding::base64;
                 crypt->hmac.hash.use_key = true;
                 if (::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_KEY_PRESET, BM_GETCHECK, 0, 0)) {
                     crypt->hmac.keypreset_id = (int)::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_KEY_LIST, CB_GETCURSEL, 0, 0);
@@ -912,7 +912,7 @@ bool DlgCrypt::prepareOptionsAdvanced()
         }
 
         // ------- password
-        crypt::Encoding pw_encoding = (crypt::Encoding)::SendDlgItemMessage(tab.basic, IDC_CRYPT_PASSWORD_ENC, CB_GETCURSEL, 0, 0);
+        nppcrypt::Encoding pw_encoding = (nppcrypt::Encoding)::SendDlgItemMessage(tab.basic, IDC_CRYPT_PASSWORD_ENC, CB_GETCURSEL, 0, 0);
         crypt->password.set(current.password.c_str(), current.password.size(), pw_encoding);
 
         // ------- modus
@@ -946,7 +946,7 @@ bool DlgCrypt::prepareOptionsEasy()
         crypt->hmac.keypreset_id = 0;
     }
     // ------- password
-    crypt->password.set(current.password.c_str(), current.password.size(), crypt::Encoding::ascii);
+    crypt->password.set(current.password.c_str(), current.password.size(), nppcrypt::Encoding::ascii);
     // ------- modus
     crypt->modus = CryptInfo::Modus::easy;
     // ------- cleanup
@@ -964,7 +964,7 @@ bool DlgCrypt::OnClickOKAdvanced()
     if (((operation == Operation::Encryption && !confirm_password) || operation == Operation::Decryption)
         && ::IsWindowEnabled(::GetDlgItem(tab.iv, IDC_CRYPT_IV_CUSTOM))
         && !!::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_CUSTOM, BM_GETCHECK, 0, 0)) {
-        crypt::UserData ivdata;
+        nppcrypt::UserData ivdata;
         invalid.iv = !checkCustomIV(ivdata, true);
         if (invalid.iv) {
             TabCtrl_SetCurSel(::GetDlgItem(_hSelf, IDC_CRYPT_TAB), 3);
@@ -988,8 +988,8 @@ bool DlgCrypt::OnClickOKAdvanced()
     }
 
     // get password
-    crypt::secure_string temp_pw_str;
-    crypt::Encoding password_enc = (crypt::Encoding)::SendDlgItemMessage(tab.basic, IDC_CRYPT_PASSWORD_ENC, CB_GETCURSEL, 0, 0);
+    nppcrypt::secure_string temp_pw_str;
+    nppcrypt::Encoding password_enc = (nppcrypt::Encoding)::SendDlgItemMessage(tab.basic, IDC_CRYPT_PASSWORD_ENC, CB_GETCURSEL, 0, 0);
     if (!checkPassword(temp_pw_str, true)) {
         ::SetFocus(::GetDlgItem(tab.basic, IDC_CRYPT_PASSWORD_ADVANCED));
         return false;
@@ -999,7 +999,7 @@ bool DlgCrypt::OnClickOKAdvanced()
         // confirmation needed
         current.password.assign(temp_pw_str);
         ::SetDlgItemText(tab.basic, IDC_CRYPT_PW_ADVANCED_CAPTION, TEXT("confirm:"));
-        if (password_enc == crypt::Encoding::ascii) {
+        if (password_enc == nppcrypt::Encoding::ascii) {
             // no password encoding: user has to reenter password for confirmation
             ::SetDlgItemText(tab.basic, IDC_CRYPT_PASSWORD_ADVANCED, TEXT(""));
             ::EnableWindow(::GetDlgItem(tab.basic, IDC_CRYPT_PASSWORD_ENC), false);
@@ -1041,7 +1041,7 @@ bool DlgCrypt::OnClickOKAdvanced()
 bool DlgCrypt::OnClickOKEasy()
 {
     // get password
-    crypt::secure_string temp_pw_str;
+    nppcrypt::secure_string temp_pw_str;
     if (!checkPassword(temp_pw_str, true)) {
         ::SetFocus(::GetDlgItem(dialogs.easy, IDC_CRYPT_PASSWORD_EASY));
         return false;
@@ -1098,42 +1098,42 @@ void DlgCrypt::checkSpinControlValue(int ctrlID)
     case IDC_CRYPT_SALT_BYTES:
     {
         edit_id = IDC_CRYPT_SALT_BYTES; spin_id = IDC_CRYPT_SALT_SPIN;
-        vmin = 1; vmax = crypt::Constants::salt_max;
+        vmin = 1; vmax = nppcrypt::Constants::salt_max;
         hwnd = tab.key;
         break;
     }
     case IDC_CRYPT_PBKDF2_ITER:
     {
         edit_id = IDC_CRYPT_PBKDF2_ITER; spin_id = IDC_CRYPT_PBKDF2_ITER_SPIN;
-        vmin = crypt::Constants::pbkdf2_iter_min; vmax = crypt::Constants::pbkdf2_iter_max;
+        vmin = nppcrypt::Constants::pbkdf2_iter_min; vmax = nppcrypt::Constants::pbkdf2_iter_max;
         hwnd = tab.key;
         break;
     }
     case IDC_CRYPT_BCRYPT_ITER:
     {
         edit_id = IDC_CRYPT_BCRYPT_ITER; spin_id = IDC_CRYPT_BCRYPT_ITER_SPIN;
-        vmin = crypt::Constants::bcrypt_iter_min; vmax = crypt::Constants::bcrypt_iter_max;
+        vmin = nppcrypt::Constants::bcrypt_iter_min; vmax = nppcrypt::Constants::bcrypt_iter_max;
         hwnd = tab.key;
         break;
     }
     case IDC_CRYPT_SCRYPT_N:
     {
         edit_id = IDC_CRYPT_SCRYPT_N; spin_id = IDC_CRYPT_SCRYPT_N_SPIN;
-        vmin = crypt::Constants::scrypt_N_min; vmax = crypt::Constants::scrypt_N_max;
+        vmin = nppcrypt::Constants::scrypt_N_min; vmax = nppcrypt::Constants::scrypt_N_max;
         hwnd = tab.key;
         break;
     }
     case IDC_CRYPT_SCRYPT_R:
     {
         edit_id = IDC_CRYPT_SCRYPT_R; spin_id = IDC_CRYPT_SCRYPT_R_SPIN;
-        vmin = crypt::Constants::scrypt_r_min; vmax = crypt::Constants::scrypt_r_max;
+        vmin = nppcrypt::Constants::scrypt_r_min; vmax = nppcrypt::Constants::scrypt_r_max;
         hwnd = tab.key;
         break;
     }
     case IDC_CRYPT_SCRYPT_P:
     {
         edit_id = IDC_CRYPT_SCRYPT_P; spin_id = IDC_CRYPT_SCRYPT_P_SPIN;
-        vmin = crypt::Constants::scrypt_p_min; vmax = crypt::Constants::scrypt_p_max;
+        vmin = nppcrypt::Constants::scrypt_p_min; vmax = nppcrypt::Constants::scrypt_p_max;
         hwnd = tab.key;
         break;
     }
@@ -1159,7 +1159,7 @@ void DlgCrypt::checkSpinControlValue(int ctrlID)
     }
 }
 
-bool DlgCrypt::checkPassword(crypt::secure_string& s, bool strict)
+bool DlgCrypt::checkPassword(nppcrypt::secure_string& s, bool strict)
 {
     if (current.modus == CryptInfo::Modus::easy) {
         getText(IDC_CRYPT_PASSWORD_EASY, s, dialogs.easy);
@@ -1172,9 +1172,9 @@ bool DlgCrypt::checkPassword(crypt::secure_string& s, bool strict)
     } else {
         getText(IDC_CRYPT_PASSWORD_ADVANCED, s, tab.basic);
         size_t slen = s.size();
-        crypt::Encoding enc = (crypt::Encoding)::SendDlgItemMessage(tab.basic, IDC_CRYPT_PASSWORD_ENC, CB_GETCURSEL, 0, 0);
-        if (enc != crypt::Encoding::ascii) {
-            crypt::UserData data(s.c_str(), enc);
+        nppcrypt::Encoding enc = (nppcrypt::Encoding)::SendDlgItemMessage(tab.basic, IDC_CRYPT_PASSWORD_ENC, CB_GETCURSEL, 0, 0);
+        if (enc != nppcrypt::Encoding::ascii) {
+            nppcrypt::UserData data(s.c_str(), enc);
             data.get(s, enc);
         }
         if (s.size() > 0 || (slen == 0 && !strict)) {
@@ -1187,13 +1187,13 @@ bool DlgCrypt::checkPassword(crypt::secure_string& s, bool strict)
     return !invalid.password;
 }
 
-bool DlgCrypt::checkCustomIV(crypt::UserData& data, bool reencode)
+bool DlgCrypt::checkCustomIV(nppcrypt::UserData& data, bool reencode)
 {
-    crypt::secure_string temp;
+    nppcrypt::secure_string temp;
     getText(IDC_CRYPT_IV_INPUT, temp, tab.iv);
     if (temp.size()) {
-        crypt::Encoding enc = (crypt::Encoding)::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_ENC, CB_GETCURSEL, 0, 0);
-        if (enc != crypt::Encoding::ascii) {
+        nppcrypt::Encoding enc = (nppcrypt::Encoding)::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_ENC, CB_GETCURSEL, 0, 0);
+        if (enc != nppcrypt::Encoding::ascii) {
             data.set(temp.c_str(), temp.size(), enc);
             if (reencode && data.size() == current.iv_length) {
                 data.get(temp, enc);
@@ -1208,13 +1208,13 @@ bool DlgCrypt::checkCustomIV(crypt::UserData& data, bool reencode)
     return (data.size() == current.iv_length);
 }
 
-bool DlgCrypt::checkHMACKey(crypt::UserData& data, bool reencode)
+bool DlgCrypt::checkHMACKey(nppcrypt::UserData& data, bool reencode)
 {
-    crypt::secure_string temp;
+    nppcrypt::secure_string temp;
     getText(IDC_CRYPT_AUTH_PW_VALUE, temp, tab.auth);
     if (temp.size()) {
-        crypt::Encoding enc = (crypt::Encoding)::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_PW_ENC, CB_GETCURSEL, 0, 0);
-        if (enc != crypt::Encoding::ascii) {
+        nppcrypt::Encoding enc = (nppcrypt::Encoding)::SendDlgItemMessage(tab.auth, IDC_CRYPT_AUTH_PW_ENC, CB_GETCURSEL, 0, 0);
+        if (enc != nppcrypt::Encoding::ascii) {
             data.set(temp.c_str(), temp.size(), enc);
             if (reencode && data.size() > 0) {
                 data.get(temp, enc);
@@ -1233,22 +1233,22 @@ bool DlgCrypt::checkHMACKey(crypt::UserData& data, bool reencode)
 /* ----------------------------------------------------------------------------------------------------------------------------------------------------------------- */
 /* ----------------------------------------------------------------------------------------------------------------------------------------------------------------- */
 
-void DlgCrypt::updateEncodingControls(crypt::Encoding enc)
+void DlgCrypt::updateEncodingControls(nppcrypt::Encoding enc)
 {
-    help.encoding.setURL(crypt::help::getHelpURL(enc));
-    if (enc == crypt::Encoding::ascii) {
+    help.encoding.setURL(nppcrypt::help::getHelpURL(enc));
+    if (enc == nppcrypt::Encoding::ascii) {
         help.encoding.setWarning(true);
-        help.encoding.setTooltip(crypt::help::getInfo(crypt::Encoding::ascii));
+        help.encoding.setTooltip(nppcrypt::help::getInfo(nppcrypt::Encoding::ascii));
     } else {
         help.encoding.setWarning(false);
-        help.encoding.setTooltip(crypt::help::getInfo(enc));
+        help.encoding.setTooltip(nppcrypt::help::getInfo(enc));
     }
 
     if (operation != Operation::Encryption) {
         return;
     }
 
-    using namespace crypt;
+    using namespace nppcrypt;
     switch (enc)
     {
     case Encoding::ascii:
@@ -1277,11 +1277,11 @@ void DlgCrypt::updateEncodingControls(crypt::Encoding enc)
     }
 }
 
-void DlgCrypt::updateHashDigestControl(crypt::Hash h, HWND hwnd, int id)
+void DlgCrypt::updateHashDigestControl(nppcrypt::Hash h, HWND hwnd, int id)
 {
     std::wstring temp_str;
     ::SendDlgItemMessage(hwnd, id, CB_RESETCONTENT, 0, 0);
-    for (crypt::help::HashDigests it(h); *it; ++it) {
+    for (nppcrypt::help::HashDigests it(h); *it; ++it) {
         temp_str = std::to_wstring(*it * 8);
         temp_str.append(TEXT(" Bits"));
         ::SendDlgItemMessage(hwnd, id, CB_ADDSTRING, 0, (LPARAM)temp_str.c_str());
@@ -1292,7 +1292,7 @@ void DlgCrypt::updateKeyDerivationControls()
 {
     switch (current.key_derivation)
     {
-    case crypt::KeyDerivation::pbkdf2:
+    case nppcrypt::KeyDerivation::pbkdf2:
     {
         ::EnableWindow(::GetDlgItem(tab.key, IDC_CRYPT_PBKDF2_HASH), true);
         ::EnableWindow(::GetDlgItem(tab.key, IDC_CRYPT_PBKDF2_HASH_LENGTH), true);
@@ -1321,7 +1321,7 @@ void DlgCrypt::updateKeyDerivationControls()
         ::EnableWindow(::GetDlgItem(tab.key, IDC_CRYPT_SALT_STATIC), c);
         break;
     }
-    case crypt::KeyDerivation::bcrypt:
+    case nppcrypt::KeyDerivation::bcrypt:
     {
         ::EnableWindow(::GetDlgItem(tab.key, IDC_CRYPT_PBKDF2_HASH), false);
         ::EnableWindow(::GetDlgItem(tab.key, IDC_CRYPT_PBKDF2_HASH_LENGTH), false);
@@ -1351,7 +1351,7 @@ void DlgCrypt::updateKeyDerivationControls()
         ::EnableWindow(::GetDlgItem(tab.key, IDC_CRYPT_SALT_STATIC), false);
         break;
     }
-    case crypt::KeyDerivation::scrypt:
+    case nppcrypt::KeyDerivation::scrypt:
     {
         ::EnableWindow(::GetDlgItem(tab.key, IDC_CRYPT_PBKDF2_HASH), false);
         ::EnableWindow(::GetDlgItem(tab.key, IDC_CRYPT_PBKDF2_HASH_LENGTH), false);
@@ -1384,8 +1384,8 @@ void DlgCrypt::updateKeyDerivationControls()
         break;
     }
     }
-    help.keyalgorithm.setURL(crypt::help::getHelpURL(current.key_derivation));
-    help.keyalgorithm.setTooltip(crypt::help::getInfo(current.key_derivation));
+    help.keyalgorithm.setURL(nppcrypt::help::getHelpURL(current.key_derivation));
+    help.keyalgorithm.setTooltip(nppcrypt::help::getInfo(current.key_derivation));
 }
 
 void DlgCrypt::updateCipherControls()
@@ -1394,13 +1394,13 @@ void DlgCrypt::updateCipherControls()
     int cipher_cat = (int)::SendDlgItemMessage(tab.basic, IDC_CRYPT_CIPHER_TYPE, CB_GETCURSEL, 0, 0);
     int cipher_index = (int)::SendDlgItemMessage(tab.basic, IDC_CRYPT_CIPHER, CB_GETCURSEL, 0, 0);
 
-    current.cipher = crypt::help::getCipherByIndex(cipher_cat, cipher_index);
+    current.cipher = nppcrypt::help::getCipherByIndex(cipher_cat, cipher_index);
 
     // refill combobox with the keylengths available for the current cipher:
     ::SendDlgItemMessage(tab.basic, IDC_CRYPT_KEYLENGTH, CB_RESETCONTENT, 0, 0);
     int keylength_index = 0;
     int i = 0;
-    for (crypt::help::CipherKeys it(current.cipher); *it; ++it, i++) {
+    for (nppcrypt::help::CipherKeys it(current.cipher); *it; ++it, i++) {
         if (current.key_length == (size_t)*it) {
             keylength_index = i;
         }
@@ -1409,11 +1409,11 @@ void DlgCrypt::updateCipherControls()
         ::SendDlgItemMessage(tab.basic, IDC_CRYPT_KEYLENGTH, CB_ADDSTRING, 0, (LPARAM)temp_str.c_str());
     }
     ::SendDlgItemMessage(tab.basic, IDC_CRYPT_KEYLENGTH, CB_SETCURSEL, keylength_index, 0);
-    current.key_length = crypt::help::getCipherKeylengthByIndex(current.cipher, keylength_index);
+    current.key_length = nppcrypt::help::getCipherKeylengthByIndex(current.cipher, keylength_index);
 
     // refill combobox with the modes available for the current cipher:
     ::SendDlgItemMessage(tab.basic, IDC_CRYPT_MODE, CB_RESETCONTENT, 0, 0);
-    for (crypt::help::CipherModes it(current.cipher); *it; ++it) {
+    for (nppcrypt::help::CipherModes it(current.cipher); *it; ++it) {
         ::SendDlgItemMessage(tab.basic, IDC_CRYPT_MODE, CB_ADDSTRING, 0, (LPARAM)help::windows::ToWCHAR(*it).c_str());
     }
 
@@ -1425,18 +1425,18 @@ void DlgCrypt::updateCipherControls()
         ::EnableWindow(::GetDlgItem(tab.basic, IDC_CRYPT_MODE), true);
         help.mode.display(true);
         // check if the current cipher supports the old mode:
-        int i = crypt::help::getModeIndex(current.cipher, current.mode);
+        int i = nppcrypt::help::getModeIndex(current.cipher, current.mode);
         if (i != -1) {
             ::SendDlgItemMessage(tab.basic, IDC_CRYPT_MODE, CB_SETCURSEL, i, 0);
         } else {
-            current.mode = crypt::help::getModeByIndex(current.cipher, 0);
+            current.mode = nppcrypt::help::getModeByIndex(current.cipher, 0);
             ::SendDlgItemMessage(tab.basic, IDC_CRYPT_MODE, CB_SETCURSEL, 0, 0);
         }
     }
 
-    help.cipher.setURL(crypt::help::getHelpURL(current.cipher));
-    help.cipher.setTooltip(crypt::help::getInfo(current.cipher));
-    if (crypt::help::checkProperty(current.cipher, crypt::WEAK)) {
+    help.cipher.setURL(nppcrypt::help::getHelpURL(current.cipher));
+    help.cipher.setTooltip(nppcrypt::help::getInfo(current.cipher));
+    if (nppcrypt::help::checkProperty(current.cipher, nppcrypt::WEAK)) {
         help.cipher.setWarning(true);
     } else {
         help.cipher.setWarning(false);
@@ -1468,7 +1468,7 @@ void DlgCrypt::updateHMACKeyControls()
 void DlgCrypt::updateCipherInfo()
 {
     size_t key_length, block_size;
-    crypt::getCipherInfo(current.cipher, current.mode, key_length, current.iv_length, block_size);
+    nppcrypt::getCipherInfo(current.cipher, current.mode, key_length, current.iv_length, block_size);
 
     // update CipherInfo Editbox
     std::wostringstream s1;
@@ -1479,13 +1479,13 @@ void DlgCrypt::updateCipherInfo()
     }
     ::SetDlgItemText(tab.basic, IDC_CRYPT_CIPHER_INFO, s1.str().c_str());
 
-    help.mode.setURL(crypt::help::getHelpURL(current.mode));
-    help.mode.setTooltip(crypt::help::getInfo(current.mode));
-    help.mode.setWarning((current.mode == crypt::Mode::ecb));
+    help.mode.setURL(nppcrypt::help::getHelpURL(current.mode));
+    help.mode.setTooltip(nppcrypt::help::getInfo(current.mode));
+    help.mode.setWarning((current.mode == nppcrypt::Mode::ecb));
 
     // update auth Salt/IV control
-    if ((current.mode == crypt::Mode::gcm || current.mode == crypt::Mode::ccm || current.mode == crypt::Mode::eax) &&
-        crypt::help::checkProperty(current.cipher, crypt::BLOCK)) {
+    if ((current.mode == nppcrypt::Mode::gcm || current.mode == nppcrypt::Mode::ccm || current.mode == nppcrypt::Mode::eax) &&
+        nppcrypt::help::checkProperty(current.cipher, nppcrypt::BLOCK)) {
         help.auth_ivsalt.display(true);
         ::ShowWindow(::GetDlgItem(tab.basic, IDC_CRYPT_AUTH_IVSALT), SW_SHOW);
     } else {
@@ -1527,13 +1527,13 @@ void DlgCrypt::updateIVControls()
     bool enableInput = false;
     if (::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_CUSTOM, BM_GETCHECK, 0, 0)) {
         enableInput = true;
-        help.iv.setTooltip(crypt::help::getInfo(crypt::IV::custom));
+        help.iv.setTooltip(nppcrypt::help::getInfo(nppcrypt::IV::custom));
     } else if (::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_ZERO, BM_GETCHECK, 0, 0)) {
-        help.iv.setTooltip(crypt::help::getInfo(crypt::IV::zero));
+        help.iv.setTooltip(nppcrypt::help::getInfo(nppcrypt::IV::zero));
     } else if (::SendDlgItemMessage(tab.iv, IDC_CRYPT_IV_KEY, BM_GETCHECK, 0, 0)) {
-        help.iv.setTooltip(crypt::help::getInfo(crypt::IV::keyderivation));
+        help.iv.setTooltip(nppcrypt::help::getInfo(nppcrypt::IV::keyderivation));
     } else {
-        help.iv.setTooltip(crypt::help::getInfo(crypt::IV::random));
+        help.iv.setTooltip(nppcrypt::help::getInfo(nppcrypt::IV::random));
     }
     ::EnableWindow(::GetDlgItem(tab.iv, IDC_CRYPT_IV_INPUT), enableInput);
     ::EnableWindow(::GetDlgItem(tab.iv, IDC_CRYPT_IV_ENC), enableInput);

--- a/src/dlg_crypt.h
+++ b/src/dlg_crypt.h
@@ -35,8 +35,8 @@ class DlgCrypt : public ModalDialog
 public:
          DlgCrypt();
     void destroy();
-    bool encryptDialog(CryptInfo* crypt, crypt::UserData* iv, const std::wstring* filename = NULL);
-    bool decryptDialog(CryptInfo* crypt, crypt::UserData* iv, const std::wstring* filename = NULL, bool disable_easymode = false);
+    bool encryptDialog(CryptInfo* crypt, nppcrypt::UserData* iv, const std::wstring* filename = NULL);
+    bool decryptDialog(CryptInfo* crypt, nppcrypt::UserData* iv, const std::wstring* filename = NULL, bool disable_easymode = false);
 
 private:
     enum class Operation { Encryption, Decryption };
@@ -44,7 +44,7 @@ private:
     /* global message callback */
     INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
-    bool setup(CryptInfo* crypt, crypt::UserData* iv, const std::wstring* filename);
+    bool setup(CryptInfo* crypt, nppcrypt::UserData* iv, const std::wstring* filename);
     void setupDialog();
     void changeActiveTab(int id);
     void setModus(CryptInfo::Modus modus);
@@ -56,13 +56,13 @@ private:
 
     /* methods to validate user-input: */
     void checkSpinControlValue(int ctrlID);
-    bool checkPassword(crypt::secure_string& s, bool strict);
-    bool checkCustomIV(crypt::UserData& data, bool reencode);
-    bool checkHMACKey(crypt::UserData& data, bool reencode);
+    bool checkPassword(nppcrypt::secure_string& s, bool strict);
+    bool checkCustomIV(nppcrypt::UserData& data, bool reencode);
+    bool checkHMACKey(nppcrypt::UserData& data, bool reencode);
 
     /* methods to change controls based on current selection */
-    void updateEncodingControls(crypt::Encoding enc);
-    void updateHashDigestControl(crypt::Hash h, HWND hwnd, int ctrlID);
+    void updateEncodingControls(nppcrypt::Encoding enc);
+    void updateHashDigestControl(nppcrypt::Hash h, HWND hwnd, int ctrlID);
     void updateKeyDerivationControls();
     void updateCipherControls();
     void updateHMACKeyControls();
@@ -72,7 +72,7 @@ private:
     Operation               operation;
     const std::wstring*     filename;
     CryptInfo*              crypt;
-    crypt::UserData*        ivdata;
+    nppcrypt::UserData*        ivdata;
     bool                    confirm_password;
     bool                    no_easymode;
 
@@ -81,10 +81,10 @@ private:
         CurStatus() : tab(-1), iv_length(0), key_length(0) {};
 
         CryptInfo::Modus        modus;
-        crypt::Cipher           cipher;
-        crypt::Mode             mode;
-        crypt::KeyDerivation    key_derivation;
-        crypt::secure_string    password;
+        nppcrypt::Cipher           cipher;
+        nppcrypt::Mode             mode;
+        nppcrypt::KeyDerivation    key_derivation;
+        nppcrypt::secure_string    password;
         int                     tab;
         size_t                  iv_length;
         size_t                  key_length;

--- a/src/dlg_hash.cpp
+++ b/src/dlg_hash.cpp
@@ -24,7 +24,7 @@ GNU General Public License for more details.
 #include "crypt_help.h"
 #include "messagebox.h"
 
-DlgHash::DlgHash(crypt::Options::Hash& opt) : ModalDialog(), options(opt)
+DlgHash::DlgHash(nppcrypt::Options::Hash& opt) : ModalDialog(), options(opt)
 {
 }
 
@@ -48,17 +48,17 @@ INT_PTR CALLBACK DlgHash::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam
         invalid_key = false;
 
         if(!help::buffer::isCurrent8Bit()) {
-            if (options.encoding == crypt::Encoding::ascii) {
-                options.encoding = crypt::Encoding::base16;
+            if (options.encoding == nppcrypt::Encoding::ascii) {
+                options.encoding = nppcrypt::Encoding::base16;
                 ::EnableWindow(::GetDlgItem(_hSelf, IDC_HASH_ENC_ASCII), false);
             }
         }
-        ::SendDlgItemMessage(_hSelf, IDC_HASH_ENC_ASCII, BM_SETCHECK, (options.encoding == crypt::Encoding::ascii), 0);
-        ::SendDlgItemMessage(_hSelf, IDC_HASH_ENC_BASE16, BM_SETCHECK, (options.encoding == crypt::Encoding::base16), 0);
-        ::SendDlgItemMessage(_hSelf, IDC_HASH_ENC_BASE32, BM_SETCHECK, (options.encoding == crypt::Encoding::base32), 0);
-        ::SendDlgItemMessage(_hSelf, IDC_HASH_ENC_BASE64, BM_SETCHECK, (options.encoding == crypt::Encoding::base64), 0);
+        ::SendDlgItemMessage(_hSelf, IDC_HASH_ENC_ASCII, BM_SETCHECK, (options.encoding == nppcrypt::Encoding::ascii), 0);
+        ::SendDlgItemMessage(_hSelf, IDC_HASH_ENC_BASE16, BM_SETCHECK, (options.encoding == nppcrypt::Encoding::base16), 0);
+        ::SendDlgItemMessage(_hSelf, IDC_HASH_ENC_BASE32, BM_SETCHECK, (options.encoding == nppcrypt::Encoding::base32), 0);
+        ::SendDlgItemMessage(_hSelf, IDC_HASH_ENC_BASE64, BM_SETCHECK, (options.encoding == nppcrypt::Encoding::base64), 0);
 
-        for(crypt::help::Hashnames it; *it; ++it) {
+        for(nppcrypt::help::Hashnames it; *it; ++it) {
             ::SendDlgItemMessage(_hSelf, IDC_HASH_ALGO, CB_ADDSTRING, 0, (LPARAM)help::windows::ToWCHAR(*it).c_str());
         }
         ::SendDlgItemMessage(_hSelf, IDC_HASH_ALGO, CB_SETCURSEL, (int)options.algorithm, 0);
@@ -75,7 +75,7 @@ INT_PTR CALLBACK DlgHash::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam
 
         setupInputEncodingSelect(_hSelf, IDC_HASH_KEY_ENC);
 
-        help_hash.setup(_hInst, _hSelf, ::GetDlgItem(_hSelf, IDC_HASH_ALGO_HELP), crypt::help::checkProperty(options.algorithm, crypt::WEAK));
+        help_hash.setup(_hInst, _hSelf, ::GetDlgItem(_hSelf, IDC_HASH_ALGO_HELP), nppcrypt::help::checkProperty(options.algorithm, nppcrypt::WEAK));
         help_enc.setup(_hInst, _hSelf, ::GetDlgItem(_hSelf, IDC_HASH_ENC_HELP));
 
         updateEncodingControls(options.encoding);
@@ -108,7 +108,7 @@ INT_PTR CALLBACK DlgHash::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam
                         return TRUE;
                     }
                     help::scintilla::getSelection(&pdata, &data_length);
-                    crypt::hash(options, buffer, { { pdata, data_length} });
+                    nppcrypt::hash(options, buffer, { { pdata, data_length} });
                     if (LOWORD(wParam) == IDC_OK) {
                         help::scintilla::replaceSelection(buffer);
                     } else {
@@ -146,22 +146,22 @@ INT_PTR CALLBACK DlgHash::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam
             }
             case IDC_HASH_ENC_ASCII:
             {
-                updateEncodingControls(crypt::Encoding::ascii);
+                updateEncodingControls(nppcrypt::Encoding::ascii);
                 break;
             }
             case IDC_HASH_ENC_BASE16:
             {
-                updateEncodingControls(crypt::Encoding::base16);
+                updateEncodingControls(nppcrypt::Encoding::base16);
                 break;
             }
             case IDC_HASH_ENC_BASE32:
             {
-                updateEncodingControls(crypt::Encoding::base32);
+                updateEncodingControls(nppcrypt::Encoding::base32);
                 break;
             }
             case IDC_HASH_ENC_BASE64:
             {
-                updateEncodingControls(crypt::Encoding::base64);
+                updateEncodingControls(nppcrypt::Encoding::base64);
                 break;
             }
             }
@@ -211,20 +211,20 @@ INT_PTR CALLBACK DlgHash::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam
 
 bool DlgHash::prepareOptions()
 {
-    options.algorithm = (crypt::Hash)::SendDlgItemMessage(_hSelf, IDC_HASH_ALGO, CB_GETCURSEL, 0, 0);
-    options.digest_length = crypt::help::getHashDigestByIndex(options.algorithm, (unsigned int)::SendDlgItemMessage(_hSelf, IDC_HASH_DIGESTS, CB_GETCURSEL, 0, 0));
+    options.algorithm = (nppcrypt::Hash)::SendDlgItemMessage(_hSelf, IDC_HASH_ALGO, CB_GETCURSEL, 0, 0);
+    options.digest_length = nppcrypt::help::getHashDigestByIndex(options.algorithm, (unsigned int)::SendDlgItemMessage(_hSelf, IDC_HASH_DIGESTS, CB_GETCURSEL, 0, 0));
 
     if (::SendDlgItemMessage(_hSelf, IDC_HASH_ENC_ASCII, BM_GETCHECK, 0, 0)) {
-        options.encoding = crypt::Encoding::ascii;
+        options.encoding = nppcrypt::Encoding::ascii;
     } else if (::SendDlgItemMessage(_hSelf, IDC_HASH_ENC_BASE16, BM_GETCHECK, 0, 0)) {
-        options.encoding = crypt::Encoding::base16;
+        options.encoding = nppcrypt::Encoding::base16;
     } else if (::SendDlgItemMessage(_hSelf, IDC_HASH_ENC_BASE32, BM_GETCHECK, 0, 0)) {
-        options.encoding = crypt::Encoding::base32;
+        options.encoding = nppcrypt::Encoding::base32;
     } else {
-        options.encoding = crypt::Encoding::base64;
+        options.encoding = nppcrypt::Encoding::base64;
     }
 
-    if (crypt::help::checkProperty(options.algorithm, crypt::HMAC_SUPPORT) || crypt::help::checkProperty(options.algorithm, crypt::KEY_SUPPORT)) {
+    if (nppcrypt::help::checkProperty(options.algorithm, nppcrypt::HMAC_SUPPORT) || nppcrypt::help::checkProperty(options.algorithm, nppcrypt::KEY_SUPPORT)) {
         options.use_key = !!::SendDlgItemMessage(_hSelf, IDC_HASH_USE_KEY, BM_GETCHECK, 0, 0);
     } else {
         options.use_key = false;
@@ -252,11 +252,11 @@ bool DlgHash::checkKey(bool updatedata)
     if (len <= 0) {
         invalid_key = true;
     } else {
-        crypt::secure_string    temp;
-        crypt::UserData         data;
-        crypt::Encoding         enc;
+        nppcrypt::secure_string    temp;
+        nppcrypt::UserData         data;
+        nppcrypt::Encoding         enc;
 
-        enc = (crypt::Encoding)::SendDlgItemMessage(_hSelf, IDC_HASH_KEY_ENC, CB_GETCURSEL, 0, 0);
+        enc = (nppcrypt::Encoding)::SendDlgItemMessage(_hSelf, IDC_HASH_KEY_ENC, CB_GETCURSEL, 0, 0);
         getText(IDC_HASH_KEY, temp);
         data.set(temp.c_str(), temp.size(), enc);
         invalid_key = (data.size() == 0 || (keylength > 0 && data.size() != keylength));
@@ -273,27 +273,27 @@ bool DlgHash::checkKey(bool updatedata)
 
 void DlgHash::onChangeAlgorithm(size_t digest)
 {
-    crypt::Hash cur_sel = (crypt::Hash)::SendDlgItemMessage(_hSelf, IDC_HASH_ALGO, CB_GETCURSEL, 0, 0);
+    nppcrypt::Hash cur_sel = (nppcrypt::Hash)::SendDlgItemMessage(_hSelf, IDC_HASH_ALGO, CB_GETCURSEL, 0, 0);
 
     // ----------------------------- Update Digests ----------------------------------------------------------------
     std::wstring temp_str;
     ::SendDlgItemMessage(_hSelf, IDC_HASH_DIGESTS, CB_RESETCONTENT, 0, 0);
 
-    for (crypt::help::HashDigests it(cur_sel); *it; ++it) {
+    for (nppcrypt::help::HashDigests it(cur_sel); *it; ++it) {
         temp_str = std::to_wstring(*it * 8);
         temp_str.append(TEXT(" Bits"));
         ::SendDlgItemMessage(_hSelf, IDC_HASH_DIGESTS, CB_ADDSTRING, 0, (LPARAM)temp_str.c_str());
     }
-    ::SendDlgItemMessage(_hSelf, IDC_HASH_DIGESTS, CB_SETCURSEL, crypt::help::getHashDigestIndex(cur_sel, (unsigned int)digest), 0);
+    ::SendDlgItemMessage(_hSelf, IDC_HASH_DIGESTS, CB_SETCURSEL, nppcrypt::help::getHashDigestIndex(cur_sel, (unsigned int)digest), 0);
 
     // ----------------------------- Key Options -------------------------------------------------------------------
-    if (crypt::help::checkProperty(cur_sel, crypt::HMAC_SUPPORT) || crypt::help::checkProperty(cur_sel, crypt::KEY_SUPPORT)) {
-        if (crypt::help::checkProperty(cur_sel, crypt::HMAC_SUPPORT)) {
+    if (nppcrypt::help::checkProperty(cur_sel, nppcrypt::HMAC_SUPPORT) || nppcrypt::help::checkProperty(cur_sel, nppcrypt::KEY_SUPPORT)) {
+        if (nppcrypt::help::checkProperty(cur_sel, nppcrypt::HMAC_SUPPORT)) {
             ::SetDlgItemText(_hSelf, IDC_HASH_USE_KEY, TEXT("HMAC:"));
         } else {
             ::SetDlgItemText(_hSelf, IDC_HASH_USE_KEY, TEXT("use key:"));
         }
-        if (crypt::help::checkProperty(cur_sel, crypt::KEY_REQUIRED)) {
+        if (nppcrypt::help::checkProperty(cur_sel, nppcrypt::KEY_REQUIRED)) {
             ::SendDlgItemMessage(_hSelf, IDC_HASH_USE_KEY, BM_SETCHECK, true, 0);
             ::EnableWindow(::GetDlgItem(_hSelf, IDC_HASH_USE_KEY), false);
             updateKeyControls(true);
@@ -303,15 +303,15 @@ void DlgHash::onChangeAlgorithm(size_t digest)
             updateKeyControls(use_key);
         }
         size_t digest_len;
-        crypt::getHashInfo(cur_sel, digest_len, keylength);
+        nppcrypt::getHashInfo(cur_sel, digest_len, keylength);
     } else {
         updateKeyControls(false);
         ::SendDlgItemMessage(_hSelf, IDC_HASH_USE_KEY, BM_SETCHECK, false, 0);
         ::EnableWindow(::GetDlgItem(_hSelf, IDC_HASH_USE_KEY), false);
     }
-    help_hash.setURL(crypt::help::getHelpURL(cur_sel));
-    help_hash.setTooltip(crypt::help::getInfo(cur_sel));
-    help_hash.setWarning(crypt::help::checkProperty(cur_sel, crypt::WEAK));
+    help_hash.setURL(nppcrypt::help::getHelpURL(cur_sel));
+    help_hash.setTooltip(nppcrypt::help::getInfo(cur_sel));
+    help_hash.setWarning(nppcrypt::help::checkProperty(cur_sel, nppcrypt::WEAK));
 }
 
 void DlgHash::updateKeyControls(bool enable)
@@ -337,14 +337,14 @@ void DlgHash::updateKeyControls(bool enable)
     }
 }
 
-void DlgHash::updateEncodingControls(crypt::Encoding enc)
+void DlgHash::updateEncodingControls(nppcrypt::Encoding enc)
 {
-    help_enc.setURL(crypt::help::getHelpURL(enc));
-    if (enc == crypt::Encoding::ascii) {
+    help_enc.setURL(nppcrypt::help::getHelpURL(enc));
+    if (enc == nppcrypt::Encoding::ascii) {
         help_enc.setWarning(true);
-        help_enc.setTooltip(crypt::help::getInfo(crypt::Encoding::ascii));
+        help_enc.setTooltip(nppcrypt::help::getInfo(nppcrypt::Encoding::ascii));
     } else {
         help_enc.setWarning(false);
-        help_enc.setTooltip(crypt::help::getInfo(enc));
+        help_enc.setTooltip(nppcrypt::help::getInfo(enc));
     }
 }

--- a/src/dlg_hash.h
+++ b/src/dlg_hash.h
@@ -26,7 +26,7 @@ GNU General Public License for more details.
 class DlgHash : public ModalDialog
 {
 public:
-            DlgHash(crypt::Options::Hash& opt);
+            DlgHash(nppcrypt::Options::Hash& opt);
     void    destroy();
 
 private:
@@ -43,9 +43,9 @@ private:
     /**** enable/disable key-controls ****/
     void updateKeyControls(bool enable);
     /**** update encoding controls ****/
-    void updateEncodingControls(crypt::Encoding enc);
+    void updateEncodingControls(nppcrypt::Encoding enc);
 
-    crypt::Options::Hash&   options;
+    nppcrypt::Options::Hash&   options;
     size_t                  keylength;
     bool                    invalid_key;
     HelpCtrl                help_enc;

--- a/src/dlg_initdata.cpp
+++ b/src/dlg_initdata.cpp
@@ -32,7 +32,7 @@ void DlgInitdata::destroy()
     ModalDialog::destroy();
 };
 
-bool DlgInitdata::doDialog(crypt::InitData* data, size_t saltlen, size_t taglen)
+bool DlgInitdata::doDialog(nppcrypt::InitData* data, size_t saltlen, size_t taglen)
 {
     pdata = data;
     saltlength = saltlen;
@@ -168,15 +168,15 @@ INT_PTR CALLBACK DlgInitdata::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 
 bool DlgInitdata::checkTag(bool updatedata)
 {
-    crypt::secure_string    temp;
+    nppcrypt::secure_string    temp;
     getText(IDC_INITDATA_TAG, temp);
     if (!temp.size()) {
         invalid_tag = true;
     } else {
-        crypt::UserData         data;
-        crypt::Encoding         enc;
+        nppcrypt::UserData         data;
+        nppcrypt::Encoding         enc;
 
-        enc = (crypt::Encoding)::SendDlgItemMessage(_hSelf, IDC_INITDATA_TAG_ENC, CB_GETCURSEL, 0, 0);
+        enc = (nppcrypt::Encoding)::SendDlgItemMessage(_hSelf, IDC_INITDATA_TAG_ENC, CB_GETCURSEL, 0, 0);
         data.set(temp.c_str(), temp.size(), enc);
         invalid_tag = (data.size() != taglength);
         if (!invalid_salt && updatedata) {
@@ -188,15 +188,15 @@ bool DlgInitdata::checkTag(bool updatedata)
 
 bool DlgInitdata::checkSalt(bool updatedata)
 {
-    crypt::secure_string    temp;
+    nppcrypt::secure_string    temp;
     getText(IDC_INITDATA_SALT, temp);
     if (!temp.size()) {
         invalid_salt = true;
     } else {
-        crypt::UserData         data;
-        crypt::Encoding         enc;
+        nppcrypt::UserData         data;
+        nppcrypt::Encoding         enc;
 
-        enc = (crypt::Encoding)::SendDlgItemMessage(_hSelf, IDC_INITDATA_SALT_ENC, CB_GETCURSEL, 0, 0);
+        enc = (nppcrypt::Encoding)::SendDlgItemMessage(_hSelf, IDC_INITDATA_SALT_ENC, CB_GETCURSEL, 0, 0);
         data.set(temp.c_str(), temp.size(), enc);
         invalid_salt = (data.size() != saltlength);
         if (!invalid_salt && updatedata) {

--- a/src/dlg_initdata.h
+++ b/src/dlg_initdata.h
@@ -25,14 +25,14 @@ class DlgInitdata : public ModalDialog
 {
 public:
                         DlgInitdata();
-    bool                doDialog(crypt::InitData* data, size_t saltlen, size_t taglen);
+    bool                doDialog(nppcrypt::InitData* data, size_t saltlen, size_t taglen);
     void                destroy();
 private:
     INT_PTR CALLBACK    run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
     bool                checkTag(bool updatedata);
     bool                checkSalt(bool updatedata);
 
-    crypt::InitData*    pdata;
+    nppcrypt::InitData*    pdata;
     size_t              saltlength;
     size_t              taglength;
     bool                invalid_salt;

--- a/src/dlg_random.cpp
+++ b/src/dlg_random.cpp
@@ -33,16 +33,16 @@ INT_PTR CALLBACK DlgRandom::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPar
     {
     case WM_INITDIALOG :
     {
-        ::SendDlgItemMessage(_hSelf, IDC_RANDOM_SPIN, UDM_SETRANGE, true, (LPARAM)MAKELONG(crypt::Constants::rand_char_max, 1));
+        ::SendDlgItemMessage(_hSelf, IDC_RANDOM_SPIN, UDM_SETRANGE, true, (LPARAM)MAKELONG(nppcrypt::Constants::rand_char_max, 1));
         ::SendDlgItemMessage(_hSelf, IDC_RANDOM_SPIN, UDM_SETBUDDY, (WPARAM)GetDlgItem(_hSelf,IDC_RANDOM_EDIT), 0);
         ::SendDlgItemMessage(_hSelf, IDC_RANDOM_SPIN, UDM_SETPOS32, 0, options.length);
 
-        if (!help::buffer::isCurrent8Bit() && options.encoding == crypt::Encoding::ascii) {
-            options.encoding = crypt::Encoding::base16;
+        if (!help::buffer::isCurrent8Bit() && options.encoding == nppcrypt::Encoding::ascii) {
+            options.encoding = nppcrypt::Encoding::base16;
             ::EnableWindow(::GetDlgItem(_hSelf, IDC_RANDOM_ENC_BINARY), false);
         }
 
-        using namespace crypt;
+        using namespace nppcrypt;
 
         switch (options.encoding) {
             case Encoding::ascii: ::SendDlgItemMessage(_hSelf, IDC_RANDOM_ENC_BINARY, BM_SETCHECK, BST_CHECKED, 0); break;
@@ -86,33 +86,33 @@ INT_PTR CALLBACK DlgRandom::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPar
             {
                 try {
                     if (::SendDlgItemMessage(_hSelf, IDC_RANDOM_ENC_BINARY, BM_GETCHECK, 0, 0) == BST_CHECKED) {
-                        options.encoding = crypt::Encoding::ascii;
+                        options.encoding = nppcrypt::Encoding::ascii;
                     } else if (::SendDlgItemMessage(_hSelf, IDC_RANDOM_ENC_BASE16, BM_GETCHECK, 0, 0) == BST_CHECKED) {
-                        options.encoding = crypt::Encoding::base16;
+                        options.encoding = nppcrypt::Encoding::base16;
                     } else if (::SendDlgItemMessage(_hSelf, IDC_RANDOM_ENC_BASE32, BM_GETCHECK, 0, 0) == BST_CHECKED) {
-                        options.encoding = crypt::Encoding::base32;
+                        options.encoding = nppcrypt::Encoding::base32;
                     } else {
-                        options.encoding = crypt::Encoding::base64;
+                        options.encoding = nppcrypt::Encoding::base64;
                     }
-                    crypt::UserData data;
+                    nppcrypt::UserData data;
                     options.length = (size_t)::SendDlgItemMessage(_hSelf, IDC_RANDOM_SPIN, UDM_GETPOS32, 0, 0);
 
                     if (::SendDlgItemMessage(_hSelf, IDC_RANDOM_SPECIALS, BM_GETCHECK, 0, 0) == BST_CHECKED) {
-                        options.restriction = crypt::UserData::Restriction::specials;
+                        options.restriction = nppcrypt::UserData::Restriction::specials;
                     } else if (::SendDlgItemMessage(_hSelf, IDC_RANDOM_DIGITS, BM_GETCHECK, 0, 0) == BST_CHECKED) {
-                        options.restriction = crypt::UserData::Restriction::digits;
+                        options.restriction = nppcrypt::UserData::Restriction::digits;
                     } else if (::SendDlgItemMessage(_hSelf, IDC_RANDOM_LETTERS, BM_GETCHECK, 0, 0) == BST_CHECKED) {
-                        options.restriction = crypt::UserData::Restriction::letters;
+                        options.restriction = nppcrypt::UserData::Restriction::letters;
                     } else if (::SendDlgItemMessage(_hSelf, IDC_RANDOM_ALPHANUM, BM_GETCHECK, 0, 0) == BST_CHECKED) {
-                        options.restriction = crypt::UserData::Restriction::alphanum;
+                        options.restriction = nppcrypt::UserData::Restriction::alphanum;
                     } else if (::SendDlgItemMessage(_hSelf, IDC_RANDOM_PASSWORD, BM_GETCHECK, 0, 0) == BST_CHECKED) {
-                        options.restriction = crypt::UserData::Restriction::password;
+                        options.restriction = nppcrypt::UserData::Restriction::password;
                     } else {
-                        options.restriction = crypt::UserData::Restriction::none;
+                        options.restriction = nppcrypt::UserData::Restriction::none;
                     }
 
                     data.random(options.length, options.restriction);
-                    crypt::secure_string str;
+                    nppcrypt::secure_string str;
                     data.get(str, options.encoding);
 
                     if (LOWORD(wParam) == IDC_OK) {
@@ -133,42 +133,42 @@ INT_PTR CALLBACK DlgRandom::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPar
             }
             case IDC_RANDOM_ENC_BINARY:
             {
-                updateEncodingControls(crypt::Encoding::ascii);
+                updateEncodingControls(nppcrypt::Encoding::ascii);
                 break;
             }
             case IDC_RANDOM_ENC_BASE16:
             {
-                updateEncodingControls(crypt::Encoding::base16);
+                updateEncodingControls(nppcrypt::Encoding::base16);
                 break;
             }
             case IDC_RANDOM_ENC_BASE32:
             {
-                updateEncodingControls(crypt::Encoding::base32);
+                updateEncodingControls(nppcrypt::Encoding::base32);
                 break;
             }
             case IDC_RANDOM_ENC_BASE64:
             {
-                updateEncodingControls(crypt::Encoding::base64);
+                updateEncodingControls(nppcrypt::Encoding::base64);
                 break;
             }
             case IDC_RANDOM_BINARY:
             {
                 if (::SendDlgItemMessage(_hSelf, IDC_RANDOM_ENC_BINARY, BM_GETCHECK, 0, 0) == BST_CHECKED) {
                     help_enc.setWarning(true);
-                    help_enc.setTooltip(crypt::help::getInfo(crypt::Encoding::ascii));
+                    help_enc.setTooltip(nppcrypt::help::getInfo(nppcrypt::Encoding::ascii));
                 }
                 break;
             }
             case IDC_RANDOM_ALPHANUM: case IDC_RANDOM_SPECIALS: case IDC_RANDOM_DIGITS: case IDC_RANDOM_LETTERS: case IDC_RANDOM_PASSWORD:
             {
                 if (::SendDlgItemMessage(_hSelf, IDC_RANDOM_ENC_BINARY, BM_GETCHECK, 0, 0) == BST_CHECKED) {
-                    updateEncodingControls(crypt::Encoding::ascii);
+                    updateEncodingControls(nppcrypt::Encoding::ascii);
                 } else if (::SendDlgItemMessage(_hSelf, IDC_RANDOM_ENC_BASE16, BM_GETCHECK, 0, 0) == BST_CHECKED) {
-                    updateEncodingControls(crypt::Encoding::base16);
+                    updateEncodingControls(nppcrypt::Encoding::base16);
                 } else if (::SendDlgItemMessage(_hSelf, IDC_RANDOM_ENC_BASE32, BM_GETCHECK, 0, 0) == BST_CHECKED) {
-                    updateEncodingControls(crypt::Encoding::base32);
+                    updateEncodingControls(nppcrypt::Encoding::base32);
                 } else {
-                    updateEncodingControls(crypt::Encoding::base64);
+                    updateEncodingControls(nppcrypt::Encoding::base64);
                 }
                 break;
             }
@@ -180,11 +180,11 @@ INT_PTR CALLBACK DlgRandom::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPar
             /* prevent out of bounds user input to length spin-control */
             if (LOWORD(wParam) == IDC_RANDOM_EDIT) {
                 if (GetWindowTextLength(::GetDlgItem(_hSelf, IDC_RANDOM_EDIT)) > 0) {
-                    crypt::secure_string temp_str;
+                    nppcrypt::secure_string temp_str;
                     getText(IDC_RANDOM_EDIT, temp_str);
                     int temp = std::stoi(temp_str.c_str());
-                    if (temp > crypt::Constants::rand_char_max) {
-                        ::SendDlgItemMessage(_hSelf, IDC_RANDOM_SPIN, UDM_SETPOS32, 0, crypt::Constants::rand_char_max);
+                    if (temp > nppcrypt::Constants::rand_char_max) {
+                        ::SendDlgItemMessage(_hSelf, IDC_RANDOM_SPIN, UDM_SETPOS32, 0, nppcrypt::Constants::rand_char_max);
                     } else if (temp < 1) {
                         ::SendDlgItemMessage(_hSelf, IDC_RANDOM_SPIN, UDM_SETPOS32, 0, 1);
                     }
@@ -201,19 +201,19 @@ INT_PTR CALLBACK DlgRandom::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPar
     return FALSE;
 }
 
-void DlgRandom::updateEncodingControls(crypt::Encoding enc)
+void DlgRandom::updateEncodingControls(nppcrypt::Encoding enc)
 {
-    help_enc.setURL(crypt::help::getHelpURL(enc));
-    if (enc == crypt::Encoding::ascii) {
+    help_enc.setURL(nppcrypt::help::getHelpURL(enc));
+    if (enc == nppcrypt::Encoding::ascii) {
         if (::SendDlgItemMessage(_hSelf, IDC_RANDOM_BINARY, BM_GETCHECK, 0, 0) == BST_CHECKED) {
             help_enc.setWarning(true);
-            help_enc.setTooltip(crypt::help::getInfo(crypt::Encoding::ascii));
+            help_enc.setTooltip(nppcrypt::help::getInfo(nppcrypt::Encoding::ascii));
         } else {
             help_enc.setWarning(false);
             help_enc.setTooltip("ascii/utf8 output");
         }
     } else {
         help_enc.setWarning(false);
-        help_enc.setTooltip(crypt::help::getInfo(enc));
+        help_enc.setTooltip(nppcrypt::help::getInfo(enc));
     }
 }

--- a/src/dlg_random.h
+++ b/src/dlg_random.h
@@ -30,7 +30,7 @@ public:
 
 private:
     INT_PTR CALLBACK    run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
-    void                updateEncodingControls(crypt::Encoding enc);
+    void                updateEncodingControls(nppcrypt::Encoding enc);
 
     RandomOptions&      options;
     HelpCtrl            help_enc;

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -203,7 +203,7 @@ void help::windows::wchar_to_utf8(const wchar_t* i, int i_len, std::string& o)
     }
 }
 
-void help::windows::wchar_to_utf8(const wchar_t* i, int i_len, crypt::secure_string& o)
+void help::windows::wchar_to_utf8(const wchar_t* i, int i_len, nppcrypt::secure_string& o)
 {
     if (i_len < -1) {
         i_len = -1;
@@ -239,7 +239,7 @@ void help::windows::utf8_to_wchar(const char* i, int i_len, std::wstring& o)
     }
 }
 
-void help::windows::utf8_to_wchar(const char* i, int i_len, crypt::secure_wstring& o)
+void help::windows::utf8_to_wchar(const char* i, int i_len, nppcrypt::secure_wstring& o)
 {
     if (i_len < -1) {
         i_len = -1;

--- a/src/help.h
+++ b/src/help.h
@@ -47,9 +47,9 @@ namespace help
         void            copyToClipboard(const unsigned char* s, size_t len);
         void            copyToClipboard(const std::basic_string<byte>& buffer);
         void            wchar_to_utf8(const wchar_t* i, int i_len, std::string& o);
-        void            wchar_to_utf8(const wchar_t* i, int i_len, crypt::secure_string& o);
+        void            wchar_to_utf8(const wchar_t* i, int i_len, nppcrypt::secure_string& o);
         void            utf8_to_wchar(const char* i, int i_len, std::wstring& o);
-        void            utf8_to_wchar(const char* i, int i_len, crypt::secure_wstring& o);
+        void            utf8_to_wchar(const char* i, int i_len, nppcrypt::secure_wstring& o);
         void            error(HWND hwnd, const char* msg);
 
         class ToWCHAR

--- a/src/modaldialog.cpp
+++ b/src/modaldialog.cpp
@@ -73,7 +73,7 @@ void ModalDialog::goToCenter()
     ::SetWindowPos(_hSelf, HWND_TOP, x, y, _rc.right - _rc.left, _rc.bottom - _rc.top, SWP_SHOWWINDOW);
 }
 
-void ModalDialog::getText(int id, crypt::secure_string& str, HWND hwnd)
+void ModalDialog::getText(int id, nppcrypt::secure_string& str, HWND hwnd)
 {
     if (hwnd == NULL) {
         hwnd = _hSelf;
@@ -83,7 +83,7 @@ void ModalDialog::getText(int id, crypt::secure_string& str, HWND hwnd)
         str.clear();
     } else {
         try {
-            crypt::secure_wstring temp;
+            nppcrypt::secure_wstring temp;
             temp.resize((size_t)length + 1);
             ::GetDlgItemText(hwnd, id, &temp[0], length + 1);
             help::windows::wchar_to_utf8(temp.c_str(), length, str);
@@ -93,7 +93,7 @@ void ModalDialog::getText(int id, crypt::secure_string& str, HWND hwnd)
     }
 }
 
-void ModalDialog::setText(int id, const crypt::secure_string& str, HWND hwnd)
+void ModalDialog::setText(int id, const nppcrypt::secure_string& str, HWND hwnd)
 {
     if (hwnd == NULL) {
         hwnd = _hSelf;
@@ -102,7 +102,7 @@ void ModalDialog::setText(int id, const crypt::secure_string& str, HWND hwnd)
         ::SetDlgItemText(hwnd, id, TEXT(""));
     } else {
         try {
-            crypt::secure_wstring temp;
+            nppcrypt::secure_wstring temp;
             help::windows::utf8_to_wchar(str.c_str(), (int)str.size(), temp);
             ::SetDlgItemText(hwnd, id, temp.c_str());
         } catch (std::exception& exc) {

--- a/src/modaldialog.h
+++ b/src/modaldialog.h
@@ -33,8 +33,8 @@ public:
 
 protected:
     void                        goToCenter();
-    void                        getText(int id, crypt::secure_string& str, HWND hwnd = NULL);
-    void                        setText(int id, const crypt::secure_string& str, HWND hwnd = NULL);
+    void                        getText(int id, nppcrypt::secure_string& str, HWND hwnd = NULL);
+    void                        setText(int id, const nppcrypt::secure_string& str, HWND hwnd = NULL);
     void                        setupInputEncodingSelect(HWND hwnd, int id);
     static INT_PTR CALLBACK     dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
     virtual INT_PTR CALLBACK    run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam) = 0;

--- a/src/nppcrypt.cpp
+++ b/src/nppcrypt.cpp
@@ -177,7 +177,7 @@ extern "C" __declspec(dllexport) void beNotified(SCNotification *notifyCode)
                 }
 
                 CryptInfo               crypt;
-                crypt::InitData         initdata;
+                nppcrypt::InitData         initdata;
                 CryptHeaderReader       header(crypt.hmac);
 
                 if (!header.parse(crypt.options, initdata, pData, data_length)) {
@@ -207,7 +207,7 @@ extern "C" __declspec(dllexport) void beNotified(SCNotification *notifyCode)
 
                 if (dlg_crypt.decryptDialog(&crypt, &initdata.iv, &filename)) {
                     std::basic_string<byte> buffer;
-                    crypt::decrypt(header.getEncrypted(), header.getEncryptedLength(), buffer, crypt.options, crypt.password, initdata);
+                    nppcrypt::decrypt(header.getEncrypted(), header.getEncryptedLength(), buffer, crypt.options, crypt.password, initdata);
 
                     ::SendMessage(hCurScintilla, SCI_CLEARALL, 0, 0);
                     ::SendMessage(hCurScintilla, SCI_APPENDTEXT, buffer.size(), (LPARAM)&buffer[0]);
@@ -292,7 +292,7 @@ extern "C" __declspec(dllexport) void beNotified(SCNotification *notifyCode)
                     throwError(no_scintilla_pointer);
                 }
 
-                crypt::InitData         initdata;
+                nppcrypt::InitData         initdata;
                 CryptHeaderWriter       header(crypt.hmac);
                 std::basic_string<byte> buffer;
                 bool                    autoencrypt = false;
@@ -328,7 +328,7 @@ extern "C" __declspec(dllexport) void beNotified(SCNotification *notifyCode)
                     }
                 }
 
-                crypt::encrypt(pData, data_length, buffer, crypt.options, crypt.password, initdata);
+                nppcrypt::encrypt(pData, data_length, buffer, crypt.options, crypt.password, initdata);
                 header.create(crypt.options, initdata, &buffer[0], buffer.size());
                 if (!old_encryption_available) {
                     crypt_files.insert(std::pair<std::wstring, CryptInfo>(path, crypt));
@@ -376,12 +376,12 @@ void EncryptDlg()
             throwInfo(no_text_selected);
         }
 
-        crypt::InitData             initdata;
+        nppcrypt::InitData             initdata;
 
         if(dlg_crypt.encryptDialog(&current.crypt, &initdata.iv)) {
 
             std::basic_string<byte>     buffer;
-            crypt::encrypt(pData, data_length, buffer, current.crypt.options, current.crypt.password, initdata);
+            nppcrypt::encrypt(pData, data_length, buffer, current.crypt.options, current.crypt.password, initdata);
 
             CryptHeaderWriter header(current.crypt.hmac);
             header.create(current.crypt.options, initdata, &buffer[0], buffer.size());
@@ -419,7 +419,7 @@ void DecryptDlg()
             throwInfo(no_text_selected);
         }
 
-        crypt::InitData     initdata;
+        nppcrypt::InitData     initdata;
         CryptHeaderReader   header(current.crypt.hmac);
 
         /* parse header and check hmac if present */
@@ -452,13 +452,13 @@ void DecryptDlg()
             /* check if salt or tag data is mising */
             size_t need_salt_len = (current.crypt.options.key.salt_bytes > 0 && initdata.salt.size() != current.crypt.options.key.salt_bytes) ? current.crypt.options.key.salt_bytes : 0;
             size_t need_tag_len = 0;
-            if (crypt::help::checkProperty(current.crypt.options.cipher, crypt::BLOCK)) {
-                if (current.crypt.options.mode == crypt::Mode::gcm && initdata.tag.size() != crypt::Constants::gcm_tag_size) {
-                    need_tag_len = crypt::Constants::gcm_tag_size;
-                } else if (current.crypt.options.mode == crypt::Mode::ccm && initdata.tag.size() != crypt::Constants::ccm_tag_size) {
-                    need_tag_len = crypt::Constants::ccm_tag_size;
-                } else if (current.crypt.options.mode == crypt::Mode::eax && initdata.tag.size() != crypt::Constants::eax_tag_size) {
-                    need_tag_len = crypt::Constants::eax_tag_size;
+            if (nppcrypt::help::checkProperty(current.crypt.options.cipher, nppcrypt::BLOCK)) {
+                if (current.crypt.options.mode == nppcrypt::Mode::gcm && initdata.tag.size() != nppcrypt::Constants::gcm_tag_size) {
+                    need_tag_len = nppcrypt::Constants::gcm_tag_size;
+                } else if (current.crypt.options.mode == nppcrypt::Mode::ccm && initdata.tag.size() != nppcrypt::Constants::ccm_tag_size) {
+                    need_tag_len = nppcrypt::Constants::ccm_tag_size;
+                } else if (current.crypt.options.mode == nppcrypt::Mode::eax && initdata.tag.size() != nppcrypt::Constants::eax_tag_size) {
+                    need_tag_len = nppcrypt::Constants::eax_tag_size;
                 }
             }
             if (need_salt_len > 0 || need_tag_len > 0) {

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -83,8 +83,8 @@ void CPreferences::load(const std::wstring& path, CurrentOptions& current)
         /* ----- files ----- */
         tinyxml2::XMLElement* xml_files = xml_nppcrypt->FirstChildElement("files");
         if (xml_files) {
-            crypt::help::getBoolean(xml_files->Attribute("enabled"), files.enable);
-            crypt::help::getBoolean(xml_files->Attribute("askonsave"), files.askonsave);
+            nppcrypt::help::getBoolean(xml_files->Attribute("enabled"), files.enable);
+            nppcrypt::help::getBoolean(xml_files->Attribute("askonsave"), files.askonsave);
             const char* pExt = xml_files->Attribute("extension");
             if (pExt && strlen(pExt) <= NPPC_FILE_EXT_MAXLENGTH) {
                 try {
@@ -102,41 +102,41 @@ void CPreferences::load(const std::wstring& path, CurrentOptions& current)
             tinyxml2::XMLElement* xml_temp = xml_current->FirstChildElement("encryption");
             if (xml_temp) {
                 bool advanced = false;
-                crypt::help::getBoolean(xml_temp->Attribute("advanced"), advanced);
+                nppcrypt::help::getBoolean(xml_temp->Attribute("advanced"), advanced);
                 current.crypt.modus = advanced ? CryptInfo::Modus::advanced : CryptInfo::Modus::easy;
                 parseCryptOptions(xml_temp, current.crypt.options);
                 tinyxml2::XMLElement* xml_hmac = xml_temp->FirstChildElement("hmac");
                 if (xml_hmac) {
-                    crypt::help::getBoolean(xml_hmac->Attribute("enabled"), current.crypt.hmac.enable);
-                    crypt::help::getHash(xml_hmac->Attribute("hash"), current.crypt.hmac.hash.algorithm);
-                    crypt::help::getUnsigned(xml_hmac->Attribute("digest-length"), current.crypt.hmac.hash.digest_length);
-                    crypt::help::getInteger(xml_hmac->Attribute("keypreset-id"), current.crypt.hmac.keypreset_id);
+                    nppcrypt::help::getBoolean(xml_hmac->Attribute("enabled"), current.crypt.hmac.enable);
+                    nppcrypt::help::getHash(xml_hmac->Attribute("hash"), current.crypt.hmac.hash.algorithm);
+                    nppcrypt::help::getUnsigned(xml_hmac->Attribute("digest-length"), current.crypt.hmac.hash.digest_length);
+                    nppcrypt::help::getInteger(xml_hmac->Attribute("keypreset-id"), current.crypt.hmac.keypreset_id);
                 }
             }
             // hash
             xml_temp = xml_current->FirstChildElement("hash");
             if (xml_temp) {
-                crypt::help::getHash(xml_temp->Attribute("algorithm"), current.hash.algorithm);
-                crypt::help::getUnsigned(xml_temp->Attribute("digest-length"), current.hash.digest_length);
-                crypt::help::getEncoding(xml_temp->Attribute("encoding"), current.hash.encoding);
-                crypt::help::getBoolean(xml_temp->Attribute("usekey"), current.hash.use_key);
+                nppcrypt::help::getHash(xml_temp->Attribute("algorithm"), current.hash.algorithm);
+                nppcrypt::help::getUnsigned(xml_temp->Attribute("digest-length"), current.hash.digest_length);
+                nppcrypt::help::getEncoding(xml_temp->Attribute("encoding"), current.hash.encoding);
+                nppcrypt::help::getBoolean(xml_temp->Attribute("usekey"), current.hash.use_key);
             }
             // random
             xml_temp = xml_current->FirstChildElement("random");
             if (xml_temp) {
-                crypt::help::getRandomRestriction(xml_temp->Attribute("restriction"), current.random.restriction);
-                crypt::help::getEncoding(xml_temp->Attribute("encoding"), current.random.encoding);
-                crypt::help::getUnsigned(xml_temp->Attribute("length"), current.random.length);
+                nppcrypt::help::getRandomRestriction(xml_temp->Attribute("restriction"), current.random.restriction);
+                nppcrypt::help::getEncoding(xml_temp->Attribute("encoding"), current.random.encoding);
+                nppcrypt::help::getUnsigned(xml_temp->Attribute("length"), current.random.length);
             }
             // convert
             xml_temp = xml_current->FirstChildElement("convert");
             if (xml_temp) {
-                crypt::help::getEncoding(xml_temp->Attribute("source-enc"), current.convert.from);
-                crypt::help::getEncoding(xml_temp->Attribute("target-enc"), current.convert.to);
-                crypt::help::getEOL(xml_temp->Attribute("eol"), current.convert.eol);
-                crypt::help::getBoolean(xml_temp->Attribute("linebreaks"), current.convert.linebreaks);
-                crypt::help::getUnsigned(xml_temp->Attribute("linelength"), current.convert.linelength);
-                crypt::help::getBoolean(xml_temp->Attribute("uppercase"), current.convert.uppercase);
+                nppcrypt::help::getEncoding(xml_temp->Attribute("source-enc"), current.convert.from);
+                nppcrypt::help::getEncoding(xml_temp->Attribute("target-enc"), current.convert.to);
+                nppcrypt::help::getEOL(xml_temp->Attribute("eol"), current.convert.eol);
+                nppcrypt::help::getBoolean(xml_temp->Attribute("linebreaks"), current.convert.linebreaks);
+                nppcrypt::help::getUnsigned(xml_temp->Attribute("linelength"), current.convert.linelength);
+                nppcrypt::help::getBoolean(xml_temp->Attribute("uppercase"), current.convert.uppercase);
             }
         }
         /* ----- default encryption ----- */
@@ -147,10 +147,10 @@ void CPreferences::load(const std::wstring& path, CurrentOptions& current)
         /* ----- encoding alphabets ----- */
         tinyxml2::XMLElement* xml_base32 = xml_nppcrypt->FirstChildElement("base32");
         if (xml_base32) {
-            crypt::byte padding = 0;
+            nppcrypt::byte padding = 0;
             const char* pPadding = xml_base32->Attribute("padding");
             if (pPadding) {
-                padding = (crypt::byte)*pPadding;
+                padding = (nppcrypt::byte)*pPadding;
             }
             const char* pAlphabet = xml_base32->Attribute("alphabet");
             if (pAlphabet && strlen(pAlphabet) == 32) {
@@ -159,10 +159,10 @@ void CPreferences::load(const std::wstring& path, CurrentOptions& current)
         }
         tinyxml2::XMLElement* xml_base64 = xml_nppcrypt->FirstChildElement("base64");
         if (xml_base64) {
-            crypt::byte padding = 0;
+            nppcrypt::byte padding = 0;
             const char* pPadding = xml_base64->Attribute("padding");
             if (pPadding) {
-                padding = (crypt::byte)*pPadding;
+                padding = (nppcrypt::byte)*pPadding;
             }
             const char* pAlphabet = xml_base64->Attribute("alphabet");
             if (pAlphabet && strlen(pAlphabet) == 64) {
@@ -204,14 +204,14 @@ void CPreferences::load(const std::wstring& path, CurrentOptions& current)
         if (current.crypt.hmac.keypreset_id < -1 || current.crypt.hmac.keypreset_id >= (int)keys.size()) {
             current.crypt.hmac.keypreset_id = 0;
         }
-        if (current.random.length > crypt::Constants::rand_char_max) {
+        if (current.random.length > nppcrypt::Constants::rand_char_max) {
             current.random.length = 32;
         }
-        crypt::help::validate(default_crypt, false);
-        crypt::help::validate(current.crypt.options, false);
-        crypt::help::validate(current.crypt.hmac.hash, false);
-        crypt::help::validate(current.hash, false);
-        crypt::help::validate(current.convert, false);
+        nppcrypt::help::validate(default_crypt, false);
+        nppcrypt::help::validate(current.crypt.options, false);
+        nppcrypt::help::validate(current.crypt.hmac.hash, false);
+        nppcrypt::help::validate(current.hash, false);
+        nppcrypt::help::validate(current.convert, false);
 
         file_loaded = true;
     } catch(...) {
@@ -227,14 +227,14 @@ void CPreferences::save(CurrentOptions& current)
             throw std::exception();
         }
         fout.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-        using namespace crypt::help;
+        using namespace nppcrypt::help;
 
         std::string eol = "\r\n";
-        const crypt::Options::Crypt& crypt = current.crypt.options;
+        const nppcrypt::Options::Crypt& crypt = current.crypt.options;
         const CryptHeader::HMAC& hmac = current.crypt.hmac;
-        const crypt::Options::Hash& hash = current.hash;
+        const nppcrypt::Options::Hash& hash = current.hash;
         const RandomOptions& random = current.random;
-        const crypt::Options::Convert& convert = current.convert;
+        const nppcrypt::Options::Convert& convert = current.convert;
         std::string file_extension;
         try {
             help::windows::wchar_to_utf8(files.extension.c_str(), (int)files.extension.size(), file_extension);
@@ -332,26 +332,26 @@ const unsigned char* CPreferences::getKey(size_t i) const
     }
 }
 
-void CPreferences::writeCryptOptions(std::ofstream& f, const crypt::Options::Crypt& opt, const std::string& indent, const std::string& eol)
+void CPreferences::writeCryptOptions(std::ofstream& f, const nppcrypt::Options::Crypt& opt, const std::string& indent, const std::string& eol)
 {
-    using namespace crypt::help;
+    using namespace nppcrypt::help;
 
     f << indent << "<basic cipher=\"" << getString(opt.cipher) << "\" key-length=\"" << opt.key.length << "\" mode=\"" << getString(opt.mode) << "\" aad=\"" << getString(opt.aad) << "\" iv=\"" << getString(opt.iv) << "\" />" << eol;
     f << indent << "<encoding enc=\"" << getString(opt.encoding.enc) << "\" eol=\"" << getString(opt.encoding.eol) << "\" linebreaks=\"" << getString(opt.encoding.linebreaks) << "\" line-length=\"" << opt.encoding.linelength << "\" uppercase=\"" << getString(opt.encoding.uppercase) << "\" />" << eol;
     f << indent << "<key saltbytes=\"" << opt.key.salt_bytes << "\" algorithm=\"" << getString(opt.key.algorithm);
     switch (opt.key.algorithm)
     {
-    case crypt::KeyDerivation::pbkdf2:
+    case nppcrypt::KeyDerivation::pbkdf2:
     {
-        f << "\" hash=\"" << crypt::help::getString((crypt::Hash)opt.key.options[0]) << "\" digest-length=\"" << opt.key.options[1] << "\" iterations=\"" << opt.key.options[2];
+        f << "\" hash=\"" << nppcrypt::help::getString((nppcrypt::Hash)opt.key.options[0]) << "\" digest-length=\"" << opt.key.options[1] << "\" iterations=\"" << opt.key.options[2];
         break;
     }
-    case crypt::KeyDerivation::bcrypt:
+    case nppcrypt::KeyDerivation::bcrypt:
     {
         f << "\" iterations=\"" << static_cast<size_t>(std::pow(2, opt.key.options[0]));
         break;
     }
-    case crypt::KeyDerivation::scrypt:
+    case nppcrypt::KeyDerivation::scrypt:
     {
         f << "\" N=\"" << static_cast<size_t>(std::pow(2, opt.key.options[0])) << "\" r=\"" << opt.key.options[1] << "\" p=\"" << opt.key.options[2];
         break;
@@ -360,49 +360,49 @@ void CPreferences::writeCryptOptions(std::ofstream& f, const crypt::Options::Cry
     f << "\" />" << eol;
 }
 
-void CPreferences::parseCryptOptions(tinyxml2::XMLElement* parent, crypt::Options::Crypt& opt)
+void CPreferences::parseCryptOptions(tinyxml2::XMLElement* parent, nppcrypt::Options::Crypt& opt)
 {
     tinyxml2::XMLElement* xml_temp = parent->FirstChildElement("basic");
     if (xml_temp) {
-        crypt::help::getCipher(xml_temp->Attribute("cipher"), opt.cipher);
-        crypt::help::getUnsigned(xml_temp->Attribute("key-length"), opt.key.length);
-        crypt::help::getCipherMode(xml_temp->Attribute("mode"), opt.mode);
-        crypt::help::getBoolean(xml_temp->Attribute("aad"), opt.aad);
-        crypt::help::getIVMode(xml_temp->Attribute("iv"), opt.iv);
+        nppcrypt::help::getCipher(xml_temp->Attribute("cipher"), opt.cipher);
+        nppcrypt::help::getUnsigned(xml_temp->Attribute("key-length"), opt.key.length);
+        nppcrypt::help::getCipherMode(xml_temp->Attribute("mode"), opt.mode);
+        nppcrypt::help::getBoolean(xml_temp->Attribute("aad"), opt.aad);
+        nppcrypt::help::getIVMode(xml_temp->Attribute("iv"), opt.iv);
     }
     xml_temp = parent->FirstChildElement("encoding");
     if (xml_temp) {
-        crypt::help::getEncoding(xml_temp->Attribute("enc"), opt.encoding.enc);
-        crypt::help::getEOL(xml_temp->Attribute("eol"), opt.encoding.eol);
-        crypt::help::getBoolean(xml_temp->Attribute("linebreaks"), opt.encoding.linebreaks);
-        crypt::help::getUnsigned(xml_temp->Attribute("linelength"), opt.encoding.linelength);
-        crypt::help::getBoolean(xml_temp->Attribute("uppercase"), opt.encoding.uppercase);
+        nppcrypt::help::getEncoding(xml_temp->Attribute("enc"), opt.encoding.enc);
+        nppcrypt::help::getEOL(xml_temp->Attribute("eol"), opt.encoding.eol);
+        nppcrypt::help::getBoolean(xml_temp->Attribute("linebreaks"), opt.encoding.linebreaks);
+        nppcrypt::help::getUnsigned(xml_temp->Attribute("linelength"), opt.encoding.linelength);
+        nppcrypt::help::getBoolean(xml_temp->Attribute("uppercase"), opt.encoding.uppercase);
     }
     xml_temp = parent->FirstChildElement("key");
     if (xml_temp) {
-        crypt::help::getUnsigned(xml_temp->Attribute("saltbytes"), opt.key.salt_bytes);
-        if (crypt::help::getKeyDerivation(xml_temp->Attribute("algorithm"), opt.key.algorithm)) {
+        nppcrypt::help::getUnsigned(xml_temp->Attribute("saltbytes"), opt.key.salt_bytes);
+        if (nppcrypt::help::getKeyDerivation(xml_temp->Attribute("algorithm"), opt.key.algorithm)) {
             switch (opt.key.algorithm) {
-            case crypt::KeyDerivation::pbkdf2:
+            case nppcrypt::KeyDerivation::pbkdf2:
             {
-                crypt::Hash thash;
-                if (crypt::help::getHash(xml_temp->Attribute("hash"), thash)) {
+                nppcrypt::Hash thash;
+                if (nppcrypt::help::getHash(xml_temp->Attribute("hash"), thash)) {
                     opt.key.options[0] = static_cast<int>(thash);
                 }
-                crypt::help::getInteger(xml_temp->Attribute("digest-length"), opt.key.options[1]);
-                crypt::help::getInteger(xml_temp->Attribute("iterations"), opt.key.options[2]);
+                nppcrypt::help::getInteger(xml_temp->Attribute("digest-length"), opt.key.options[1]);
+                nppcrypt::help::getInteger(xml_temp->Attribute("iterations"), opt.key.options[2]);
                 break;
             }
-            case crypt::KeyDerivation::bcrypt:
+            case nppcrypt::KeyDerivation::bcrypt:
             {
-                crypt::help::getInteger(xml_temp->Attribute("iterations"), opt.key.options[0], true);
+                nppcrypt::help::getInteger(xml_temp->Attribute("iterations"), opt.key.options[0], true);
                 break;
             }
-            case crypt::KeyDerivation::scrypt:
+            case nppcrypt::KeyDerivation::scrypt:
             {
-                crypt::help::getInteger(xml_temp->Attribute("N"), opt.key.options[0], true);
-                crypt::help::getInteger(xml_temp->Attribute("r"), opt.key.options[1]);
-                crypt::help::getInteger(xml_temp->Attribute("p"), opt.key.options[2]);
+                nppcrypt::help::getInteger(xml_temp->Attribute("N"), opt.key.options[0], true);
+                nppcrypt::help::getInteger(xml_temp->Attribute("r"), opt.key.options[1]);
+                nppcrypt::help::getInteger(xml_temp->Attribute("p"), opt.key.options[2]);
                 break;
             }
             }

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -28,26 +28,26 @@ struct CryptInfo {
     enum class Modus : unsigned { easy, advanced };
     CryptInfo() : modus(Modus::easy) {};
 
-    crypt::Options::Crypt   options;
-    crypt::UserData         password;
+    nppcrypt::Options::Crypt   options;
+    nppcrypt::UserData         password;
     CryptHeader::HMAC       hmac;
     Modus                   modus;
 };
 
 struct RandomOptions
 {
-    RandomOptions() : length(16), restriction(crypt::UserData::Restriction::alphanum), encoding(crypt::Encoding::ascii) {};
+    RandomOptions() : length(16), restriction(nppcrypt::UserData::Restriction::alphanum), encoding(nppcrypt::Encoding::ascii) {};
     size_t                          length;
-    crypt::UserData::Restriction    restriction;
-    crypt::Encoding                 encoding;
+    nppcrypt::UserData::Restriction    restriction;
+    nppcrypt::Encoding                 encoding;
 };
 
 struct CurrentOptions
 {
     CryptInfo               crypt;
-    crypt::Options::Hash    hash;
+    nppcrypt::Options::Hash    hash;
     RandomOptions           random;
-    crypt::Options::Convert convert;
+    nppcrypt::Options::Convert convert;
 };
 
 class CPreferences
@@ -79,23 +79,23 @@ public:
     const TCHAR*            getKeyLabel(size_t i) const;
     const unsigned char*    getKey(size_t i) const;
 
-    const crypt::Options::Crypt& getDefaultEncryption() { return default_crypt; };
-    const crypt::EncodingAlphabet* getBase32Alphabet() { return &base32_alphabet; };
-    const crypt::EncodingAlphabet* getBase64Alphabet() { return &base64_alphabet; };
+    const nppcrypt::Options::Crypt& getDefaultEncryption() { return default_crypt; };
+    const nppcrypt::EncodingAlphabet* getBase32Alphabet() { return &base32_alphabet; };
+    const nppcrypt::EncodingAlphabet* getBase64Alphabet() { return &base64_alphabet; };
 
 private:
     CPreferences(CPreferences const&);
     CPreferences& operator=(CPreferences const&);
 
-    void                    writeCryptOptions(std::ofstream& f, const crypt::Options::Crypt& opt, const std::string& indent, const std::string& eol);
-    void                    parseCryptOptions(tinyxml2::XMLElement* parent, crypt::Options::Crypt& opt);
+    void                    writeCryptOptions(std::ofstream& f, const nppcrypt::Options::Crypt& opt, const std::string& indent, const std::string& eol);
+    void                    parseCryptOptions(tinyxml2::XMLElement* parent, nppcrypt::Options::Crypt& opt);
 
     std::vector<KeyPreset>  keys;
     std::wstring            filepath;
     bool                    file_loaded;
-    crypt::Options::Crypt   default_crypt;
-    crypt::EncodingAlphabet base32_alphabet;
-    crypt::EncodingAlphabet base64_alphabet;
+    nppcrypt::Options::Crypt   default_crypt;
+    nppcrypt::EncodingAlphabet base32_alphabet;
+    nppcrypt::EncodingAlphabet base64_alphabet;
 };
 
 extern CPreferences&        preferences;


### PR DESCRIPTION
1. Fix name conflict of namespace `crypt` (against `crypt` function in `<unistd.h>`) by renaming it to `nppcrypt`.
2. Fix parallel build issues.