### PR TITLE
Add Apple Silicon M1 Mac support

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -24,7 +24,7 @@ ifeq ($(mode),debug)
 else
 	CFLAGS += -g2 -Os -fdata-sections -ffunction-sections -DNDEBUG
 	CXXFLAGS += -g2 -Os -fdata-sections -ffunction-sections -DNDEBUG
-	LDFLAGS += -static -s
+	LDFLAGS += 
 	SUBDIR := release
 endif
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ features: encryption/decryption with symmetric ciphers like aes. hash-functions 
 1.0.1.6:
 * x64:: [download](https://github.com/jeanpaulrichter/nppcrypt/releases/download/1.0.1.6/nppcrypt_1.0.1.6_x64.zip) (md5: 4D10E802AD6CA28E204FD71FDDAE9068)
 * x86:: [download](https://github.com/jeanpaulrichter/nppcrypt/releases/download/1.0.1.6/nppcrypt_1.0.1.6_x86.zip) (md5: 94886345841AE634B57552D1320103E6)
-* Linux version: see [FAQ: compiling nppcrypt](#faq_6)
+* Linux & Mac version: see [FAQ: compiling nppcrypt](#faq_6)
 ###### old versions:
 * 1.0.1.5: [x86](https://github.com/jeanpaulrichter/nppcrypt/releases/download/1.0.1.5/nppcrypt_1.0.1.5_x86.zip) (md5: 2D5D894EBA15A653FADD1776B66417BB), [x64](https://github.com/jeanpaulrichter/nppcrypt/releases/download/1.0.1.5/nppcrypt_1.0.1.5_x64.zip) (md5: B2BD52509310A324E0A8090DFC8CCB70)
 * 1.0.1.4: [x86](http://www.cerberus-design.de/nppcrypt_1.0.1.4_x86.zip) (md5: 038E4EF7D01858A3ED32F49ACAAADAC5), [x64](http://www.cerberus-design.de/nppcrypt_1.0.1.4_x64.zip) (md5: 0CE1EE405A930D083F74CB085667E73F)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Sadly 1.0.1.6 is not backward compatible (mostly because of a changed header for
 Download repository, open nppcrypt.sln under projects/msvc2017 and compile the project "nppcrypt" or the project "cmdline" (Microsoft Visual Studio 2017 needed)
 
 
-- *Linux*:
+- *Linux & Mac*:
 ```
 git clone https://github.com/jeanpaulrichter/nppcrypt.git
 cd nppcrypt

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -999,8 +999,10 @@ int main(int argc, char** argv)
         return app.exit(e);
     } catch (std::exception& e) {
         std::cerr << "error:" << e.what() << std::endl;
+        return 1;
     } catch (...) {
         std::cerr << "unexpected error." << std::endl;
+        return 2;
     }
     return 0;
 }

--- a/src/cryptopp/GNUmakefile
+++ b/src/cryptopp/GNUmakefile
@@ -50,7 +50,7 @@ IS_PPC32 := $(shell echo "$(HOSTX)" | $(GREP) -v "64" | $(GREP) -i -c -E 'ppc|po
 IS_PPC64 := $(shell echo "$(HOSTX)" | $(GREP) -i -c -E 'ppc64|powerpc64|power64')
 IS_SPARC32 := $(shell echo "$(HOSTX)" | $(GREP) -v "64" | $(GREP) -i -c -E 'sun|sparc')
 IS_SPARC64 := $(shell echo "$(HOSTX)" | $(GREP) -i -c -E 'sun|sparc64')
-IS_ARM32 := $(shell echo "$(HOSTX)" | $(GREP) -i -c -E 'arm|armhf|arm7l|eabihf')
+IS_ARM32 := $(shell echo "$(HOSTX)" | $(GREP) -i -c -E 'arm\>|armhf|arm7l|eabihf')
 IS_ARMV8 := $(shell echo "$(HOSTX)" | $(GREP) -i -c -E 'aarch32|aarch64|arm64|armv8')
 
 IS_NEON := $(shell $(CXX) $(CXXFLAGS) -dumpmachine 2>/dev/null | $(GREP) -i -c -E 'armv7|armhf|arm7l|eabihf|armv8|aarch32|aarch64')

--- a/src/scrypt/config.h
+++ b/src/scrypt/config.h
@@ -1,8 +1,11 @@
 #define VERSION "1.2.1"
 
+// see https://github.com/cpredef/predef
+#if (defined(_M_IX86) || defined(__i386__) || defined(__i386) || defined(_X86_) || defined(__I86__) || defined(__INTEL__)) && !CRYPTOPP_BOOL_X32
 #define CPUSUPPORT_X86_CPUID 1
 #define CPUSUPPORT_X86_SSE2 1
 #define CPUSUPPORT_X86_AESNI 1
+#endif
 
 #define HAVE_INTTYPES_H 1
 #define HAVE_MEMORY_H 1


### PR DESCRIPTION
Add Mac build support on Apple M1 Silicon 

- disabled static linking
- arm64 misidentification as arm32
- disable x86 macros in scrypt

Compiled using `gcc --version`
Apple clang version 14.0.0 (clang-1400.0.29.202)
Target: arm64-apple-darwin21.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin

closes #32